### PR TITLE
Initial GridDAO implementation

### DIFF
--- a/lib/grid_dao.es6.js
+++ b/lib/grid_dao.es6.js
@@ -1,0 +1,51 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+foam.CLASS({
+  package: 'org.chromium.apis.web',
+  name: 'GridRow',
+
+  properties: [
+    {
+      name: 'id',
+    },
+    {
+      class: 'Array',
+      documentation: 'Data items parallel to GridDAO.cols.',
+      name: 'data',
+    },
+  ],
+});
+
+foam.CLASS({
+  package: 'org.chromium.apis.web',
+  name: 'GridDAO',
+  extends: 'foam.dao.ProxyDAO',
+
+  documentation: 'DAO of GridRows that stores GridRow.data metadata.',
+
+  properties: [
+    {
+      name: 'of',
+      value: 'org.chromium.apis.web.GridRow',
+    },
+    {
+      class: 'Array',
+      documentation: 'Column metadata items parallel to GridRow.data.',
+      name: 'cols',
+      final: true,
+      required: true,
+    },
+  ],
+
+  methods: [
+    function colIndexOf(col) {
+      const cols = this.cols;
+      for (let i = 0; i < cols.length; i++) {
+        if (foam.util.equals(cols[i], col)) return i;
+      }
+      return -1;
+    },
+  ],
+});

--- a/lib/grid_dao.es6.js
+++ b/lib/grid_dao.es6.js
@@ -40,12 +40,18 @@ foam.CLASS({
   ],
 
   methods: [
-    function colIndexOf(col) {
-      const cols = this.cols;
-      for (let i = 0; i < cols.length; i++) {
-        if (foam.util.equals(cols[i], col)) return i;
-      }
-      return -1;
+    {
+      name: 'colIndexOf',
+      documentation: `Return the array index (in "cols") of "col". If "col" does
+          not appear in "cols", then return -1. Comparisons performed using
+          "FOAM equality": foam.util.compare().`,
+      code: function(col) {
+        const cols = this.cols;
+        for (let i = 0; i < cols.length; i++) {
+          if (foam.util.equals(cols[i], col)) return i;
+        }
+        return -1;
+      },
     },
   ],
 });

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -53,6 +53,7 @@ beforeAll(function() {
   require('../../lib/confluence/metric_computer_service.es6.js');
   require('../../lib/confluence/set_ops.es6.js');
   require('../../lib/dao_container.es6.js');
+  require('../../lib/grid_dao.es6.js');
   require('../../lib/http_json_dao.es6.js');
   require('../../lib/indexed_dao.es6.js');
   require('../../lib/json_dao_container.es6.js');

--- a/test/any/grid_dao-test.es6.js
+++ b/test/any/grid_dao-test.es6.js
@@ -1,0 +1,84 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+
+describe('GridDAO', () => {
+  fit('should use FOAM object equality for colIndexOf', () => {
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'RGBA',
+
+      properties: [
+        {
+          class: 'Float',
+          name: 'r',
+        },
+        {
+          class: 'Float',
+          name: 'g',
+        },
+        {
+          class: 'Float',
+          name: 'b',
+        },
+        {
+          class: 'Float',
+          name: 'a',
+          value: 1.0,
+        },
+      ],
+    });
+
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'Color',
+
+      properties: [
+        {
+          class: 'String',
+          name: 'name',
+        },
+        {
+          class: 'FObjectProperty',
+          of: 'org.chromium.apis.web.test.RGBA',
+          name: 'rgba',
+        },
+      ],
+    });
+
+    const RGBA = org.chromium.apis.web.test.RGBA;
+    const Color = org.chromium.apis.web.test.Color;
+
+    const dao = org.chromium.apis.web.GridDAO.create({
+      cols: [
+        Color.create({name: 'red', rgba: RGBA.create({r: 1.0})}),
+        Color.create({name: 'green', rgba: RGBA.create({g: 1.0})}),
+        Color.create({name: 'blue', rgba: RGBA.create({b: 1.0})}),
+      ],
+    });
+
+    expect(dao.colIndexOf(Color.create())).toBe(-1);
+    expect(dao.colIndexOf(null)).toBe(-1);
+    expect(dao.colIndexOf(undefined)).toBe(-1);
+    expect(dao.colIndexOf(foam.core.FObject.create())).toBe(-1);
+    expect(dao.colIndexOf(-1)).toBe(-1);
+    expect(dao.colIndexOf(true)).toBe(-1);
+    expect(dao.colIndexOf(false)).toBe(-1);
+    expect(dao.colIndexOf(Infinity)).toBe(-1);
+
+    expect(dao.colIndexOf(Color.create({
+      name: 'red',
+      rgba: RGBA.create({r: 1.0}),
+    }))).toBe(0);
+    expect(dao.colIndexOf(Color.create({
+      name: 'green',
+      rgba: RGBA.create({g: 1.0}),
+    }))).toBe(1);
+    expect(dao.colIndexOf(Color.create({
+      name: 'blue',
+      rgba: RGBA.create({b: 1.0}),
+    }))).toBe(2);
+  });
+});


### PR DESCRIPTION
This will be used to represent Release<-->API data as a big table of bools which can be skipped/limited and "projected" (to filter out releases not currently in view). It is hoped that this representation can retire API Matrix, simplify client code, and decrease time-to-data.