### PR TITLE
Search query UI with manual test

### DIFF
--- a/lib/parse/parser_interpreter.es6.js
+++ b/lib/parse/parser_interpreter.es6.js
@@ -29,6 +29,7 @@ foam.CLASS({
   methods: [
     function parseString(str, opt_name) {
       const parse = this.queryGrammar.getParse(str, opt_name);
+      if (!parse) throw new Error(`QueryParser failed to parse: "${str}"`);
       return {result: parse.value, rest: str.substr(parse.pos)};
     },
     function matchReleaseColumns_(values) {
@@ -60,7 +61,7 @@ foam.CLASS({
                         repeat0, seq, seq1, str, sym) {
         return {
           START: sym('query'),
-          query: seq1(1, sym('ws'), sym('or'), sym('ws')),
+          query: optional(seq1(1, sym('ws'), sym('or'), sym('ws'))),
 
           or: plus(sym('and'), sym('orDelim')),
           orDelim: seq(sym('ws'), alt(literalIC('OR'), '|'), sym('ws')),
@@ -94,6 +95,9 @@ foam.CLASS({
         };
       },
       actions: [
+        function query(optionalOr) {
+          return optionalOr || this.TRUE;
+        },
         function or(exprs) {
           if (exprs.length === 0) return this.TRUE;
           if (exprs.length === 1) return exprs[0];

--- a/lib/u2/SearchView.es6.js
+++ b/lib/u2/SearchView.es6.js
@@ -108,12 +108,13 @@ foam.CLASS({
   methods: [
     function initE() {
       this.addClass(this.myClass())
-        .start('i').addClass('material-icons').addClass(this.myClass('icon'))
-        .add('search').end()
+          .start('i').addClass('material-icons').addClass(this.myClass('icon'))
+          .add('search')
+          .end()
           .tag(this.viewSpec, {}, this.view$)
-        .start('i').addClass('material-icons')
-        .addClass(this.myClass('icon'))
-        .addClass(this.myClass('button'))
+          .start('i').addClass('material-icons')
+          .addClass(this.myClass('icon'))
+          .addClass(this.myClass('button'))
           .addClass(this.slot(data => data ? '' : 'hide',
                               this.view$.dot('data')))
           .add('close')

--- a/lib/u2/SearchView.es6.js
+++ b/lib/u2/SearchView.es6.js
@@ -1,0 +1,139 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+require('../parse/parser_interpreter.es6.js');
+
+foam.CLASS({
+  package: 'org.chromium.apis.web',
+  name: 'SearchView',
+  extends: 'foam.u2.View',
+
+  documentation: `A search box decorated with a magnifying glass label and (when
+      search query is non-empty) clear button. Query strings are parsed and the
+      result (if any) is bound to the imported predicate.`,
+
+  requires: [
+    'org.chromium.parse.QueryParser',
+  ],
+  imports: [
+    'error',
+    'predicate',
+  ],
+
+  css: `
+    ^ {
+      display: flex;
+    }
+
+    ^icon {
+      z-index: 2;
+      display: inline-block;
+      padding: 1rem;
+    }
+
+    ^button {
+      flex-grow: 0;
+      flex-shrink: 0;
+      background-color: inherit;
+      color: inherit;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
+
+    ^button:hover {
+      background-color: rgba(0, 0, 0, 0.2);
+      cursor: pointer;
+    }
+
+    ^ input {
+      color: inherit;
+      background-color: inherit;
+      font-family: inherit;
+      font-size: inherit;
+      flex-grow: 1;
+      border: none;
+      outline: none;
+      display: inline-block;
+      line-height: 2rem;
+      padding: 0.5rem 0;
+    }
+
+    ^ .hide {
+      display: none;
+    }
+  `,
+
+  properties: [
+    {
+      class: 'Class',
+      name: 'of',
+      documentation: 'The class of objects being searched for.',
+      required: true,
+    },
+    {
+      name: 'queryParser',
+      documentation: `The parser used to generate a filter predicate from the
+          query string.`,
+      factory: function() {
+        return this.QueryParser.create({of: this.of});
+      },
+    },
+    {
+      class: 'foam.u2.ViewSpec',
+      name: 'viewSpec',
+      documentation: 'Spec for constructing search input view.',
+      value: {
+        class: 'foam.u2.tag.Input',
+        onKey: true,
+      },
+    },
+    {
+      name: 'view',
+    },
+  ],
+
+  actions: [
+    {
+      name: 'clear',
+      documentation: 'Clear the current query string.',
+      keyboardShortcuts: [27], // Escape.
+      code: function() { this.view.data = ''; },
+    },
+  ],
+
+  methods: [
+    function initE() {
+      this.addClass(this.myClass())
+        .start('i').addClass('material-icons').addClass(this.myClass('icon'))
+        .add('search').end()
+          .tag(this.viewSpec, {}, this.view$)
+        .start('i').addClass('material-icons')
+        .addClass(this.myClass('icon'))
+        .addClass(this.myClass('button'))
+          .addClass(this.slot(data => data ? '' : 'hide',
+                              this.view$.dot('data')))
+          .add('close')
+          .on('click', () => this.clear());
+      this.view.data$.mapTo(
+          this.predicate$,
+          queryStr => {
+            let ret = this.predicate;
+            try {
+              const parse = this.queryParser.parseString(queryStr || '');
+              // TODO(markdittmer): Surface report of partial parse when
+              // parse.rest is not "".
+              ret = parse.result;
+            } catch (e) {
+              // TODO(markdittmer): Surface parse failure in UI.
+              this.error('Query parser error: ', e);
+            }
+            return ret;
+          });
+      this.SUPER();
+    },
+  ],
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -9984,7 +9984,8 @@
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
               "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "json-schema": {
               "version": "0.2.3",

--- a/test/manual/SearchView.html
+++ b/test/manual/SearchView.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:400,500,700">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons">
+    <style>
+      body {
+        font-family: 'Roboto', sans-serif;
+        color: rgba(0, 0, 0, 0.8);
+        width: 100vw;
+        height: 100vh;
+        display: grid;
+        overflow: hidden;
+        margin: 0;
+        padding: 0;
+        grid-template-rows: min-content 1fr;
+      }
+    </style>
+    <script type="text/javascript" src="../../static/bundle/vendors.bundle.js"></script>
+    <script type="text/javascript" src="../../static/bundle/foam.bundle.js"></script>
+    <script type="text/javascript" src="../../static/bundle/ui_test.bundle.js"></script>
+  </head>
+  <body>
+    <div style="padding: 16px">
+      Expectations:
+      <ul>
+        <li>
+          Search box with search icon on left
+        </li><li>
+          Interactive "X" button appears when query non-empty; clicking
+          clears query
+        </li><li>
+          Pressing Escape when input is focused clears query
+        </li><li>
+          Default predicate is True
+        </li><li>
+          Predicate parsed until part is not understood (e.g., "a b ~c"
+          parses to keywords "a" and "b")
+        </li><li>
+          Supports structured query "in:a" "notin:a" (in/not in browser
+          starting with a); "count:2" (in exactly 2 of selected browsers)
+        </li><li>
+          Predicate remains unchanged when parse totally fails (e.g., paste
+          in string: "in:notarealbrowser")
+        </li>
+      </ul>
+    </div>
+    <script type="text/javascript">
+      global.uiTestEnvPromise
+	    .then(env => env.searchViewTestView.write(document));
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This includes:

- Search box with label
- "Clear" action (via Escape key or "X" button)
- Query parser integration: Bind parse result to imported `predicate` on successful parse