### PR TITLE
 Test and implement: New api_service DAO

### DIFF
--- a/lib/dao/api_service_dao.es6.js
+++ b/lib/dao/api_service_dao.es6.js
@@ -1,0 +1,74 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+require('./indexed_dao.es6.js');
+
+foam.CLASS({
+  name: 'ApiServiceDAO',
+  package: 'org.chromium.apis.web',
+  extends: 'foam.dao.ProxyDAO',
+
+  documentation: `The top-level DAO for exposing DAOs in the AngularJS API
+      service. This DAO is responsible for coordinating fetching and caching
+      strategies to balance first data load / ongoing responsiveness
+      tradeoffs.`,
+
+  requires: [
+    'foam.box.SkeletonBox',
+    'foam.dao.ClientDAO',
+    'foam.dao.RestDAO',
+    'org.chromium.apis.web.WorkerDAO',
+  ],
+
+  properties: [
+    {
+      class: 'String',
+      name: 'name',
+      value: 'dao',
+    },
+    {
+      class: 'String',
+      name: 'baseURL',
+      documentation: 'Base URL used for remote RestDAO.',
+      required: true,
+    },
+    {
+      class: 'FObjectProperty',
+      of: 'foam.box.BoxRegistryBox',
+      name: 'workerRegistry',
+      documentation: `Remote foam.box.Box registry in worker that will host
+          data cache.`,
+      required: true,
+    },
+    {
+      name: 'delegate',
+      transient: true,
+      factory: function() {
+        this.validate();
+
+        const clientDAO = this.ClientDAO.create({
+          delegate: this.workerRegistry
+              .register(this.name, null, this.SkeletonBox.create({
+                data: this.WorkerDAO.create({
+                  of: this.of,
+                  baseURL: this.baseURL,
+                }),
+              })),
+        });
+
+        // Change delegate to client once it has finished caching in worker.
+        clientDAO.limit(1).select().then(() => {
+          this.delegate = clientDAO;
+        });
+
+        // Initially, hit network directly to fetch data.
+        return this.RestDAO.create({
+          of: this.of,
+          baseURL: this.baseURL,
+        });
+      },
+    },
+  ],
+});

--- a/lib/dao/api_service_dao.es6.js
+++ b/lib/dao/api_service_dao.es6.js
@@ -4,6 +4,7 @@
 'use strict';
 
 require('./indexed_dao.es6.js');
+require('./worker_dao.es6.js');
 
 foam.CLASS({
   name: 'ApiServiceDAO',
@@ -36,7 +37,7 @@ foam.CLASS({
     },
     {
       class: 'FObjectProperty',
-      of: 'foam.box.BoxRegistryBox',
+      of: 'foam.box.BoxRegistry',
       name: 'workerRegistry',
       documentation: `Remote foam.box.Box registry in worker that will host
           data cache.`,

--- a/lib/dao/worker_dao.es6.js
+++ b/lib/dao/worker_dao.es6.js
@@ -21,7 +21,6 @@ foam.CLASS({
     'foam.dao.CachingDAO',
     'foam.dao.MDAO',
     'foam.dao.RestDAO',
-    'org.chromium.apis.web.RestDAOFactory',
   ],
   imports: ['container'],
 

--- a/test/any/dao/api_service_dao-test.es6.js
+++ b/test/any/dao/api_service_dao-test.es6.js
@@ -149,6 +149,10 @@ describe('ApiServiceDAO', () => {
       workerRegistry: foam.box.Context.create(null, workerCtx).registry,
     }, ctx);
     const initialDelegate = dao.delegate;
+
+    // Assert that a property change event is fired by dao.delegate$ property
+    // slot. This test will time out (because done() isn't called) if
+    // dao.delegate is not set after this subscription is established.
     dao.delegate$.sub(done);
   });
 });

--- a/test/any/dao/api_service_dao-test.es6.js
+++ b/test/any/dao/api_service_dao-test.es6.js
@@ -1,0 +1,154 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+// TODO(markdittmer): Should probably more consistently replace dependent DAOs
+// with fake implementations.
+describe('ApiServiceDAO', () => {
+  let pkg;
+  let ctx;
+  beforeEach(() => {
+    pkg = org.chromium.apis.web;
+
+    foam.CLASS({
+      name: 'Thing',
+      package: 'org.chromium.apis.web.test',
+
+      properties: ['id'],
+    });
+
+    foam.CLASS({
+      name: 'FakeContainer',
+      package: 'org.chromium.apis.web.test',
+
+      exports: ['as container'],
+    });
+    ctx = foam.box.Context.create(null, pkg.test.FakeContainer.create())
+        .__subContext__;
+  });
+
+  it('should require baseURL', () => {
+    expect(() => pkg.ApiServiceDAO.create({
+      of: pkg.test.Thing,
+      workerRegistry: foam.box.Context.create(null, ctx).registry,
+    }, ctx)
+        // Access delegate to trigger lazy factory responsible for validate().
+        .delegate).toThrow();
+  },);
+
+  it('should require workerRegistry', () => {
+    expect(() => pkg.ApiServiceDAO.create({
+      of: pkg.test.Thing,
+      baseURL: 'https://example.com/thingDAO',
+    }, ctx)
+        // Access delegate to trigger lazy factory responsible for validate().
+        .delegate).toThrow();
+  });
+
+  it('should instantiate with all requirements', () => {
+    expect(() => pkg.ApiServiceDAO.create({
+      of: pkg.test.Thing,
+      baseURL: 'https://example.com/thingDAO',
+      workerRegistry: foam.box.Context.create(null, ctx).registry,
+    }, ctx)
+        // Access delegate to trigger lazy factory responsible for validate().
+        .delegate).not.toThrow();
+  });
+
+  it('should pass baseURL to WorkerDAO', () => {
+    const baseURL = 'https://example.com/thingDAO';
+    let numWorkerDAOs = 0;
+    foam.CLASS({
+      name: 'MockWorkerDAO',
+      package: 'org.chromium.apis.web.test',
+      extends: 'org.chromium.apis.web.WorkerDAO',
+
+      properties: [
+        {
+          class: 'Int',
+          name: 'baseURLSetCount',
+        },
+        {
+          name: 'baseURL',
+          postSet: function(_, nu) {
+            expect(nu).toBe(baseURL);
+          },
+        },
+      ],
+
+      methods: [
+        function init() {
+          this.SUPER();
+          numWorkerDAOs++;
+          expect(this.baseURL).toBe(baseURL);
+        },
+      ],
+    });
+
+    ctx.register(pkg.test.MockWorkerDAO, 'org.chromium.apis.web.WorkerDAO');
+
+    pkg.ApiServiceDAO.create({
+      of: pkg.test.Thing,
+      baseURL,
+      workerRegistry: foam.box.Context.create(null, ctx).registry,
+    }, ctx)
+        // Access delegate to trigger lazy factory.
+        .delegate;
+
+    // Registry may involve instantiating more than one WorkerDAO, but at least
+    // one should be created.
+    expect(numWorkerDAOs).toBeGreaterThan(0);
+  });
+
+  it('should register worker DAO under given name', () => {
+    const serviceName = 'serviceName';
+    let numRegisters = 0;
+    foam.CLASS({
+      name: 'MockBoxRegistry',
+      package: 'org.chromium.apis.web.test',
+      extends: 'foam.box.BoxRegistryBox',
+
+      methods: [
+        function register(name, service, box) {
+          expect(name).toBe(serviceName);
+          numRegisters++;
+          return this.SUPER(name, service, box);
+        },
+      ],
+    });
+
+    const workerCtx = foam.createSubContext({});
+    workerCtx.register(pkg.test.MockBoxRegistry, 'foam.box.BoxRegistryBox');
+    const workerRegistry = foam.box.Context.create(null, workerCtx).registry;
+
+    pkg.ApiServiceDAO.create({
+      of: pkg.test.Thing,
+      name: serviceName,
+      baseURL: 'https://example.com/thingDAO',
+      workerRegistry,
+    }, ctx)
+        // Access delegate to trigger lazy factory.
+        .delegate;
+
+    expect(numRegisters).toBeGreaterThan(0);
+  });
+
+  it('should change delegate after async select()', done => {
+    const workerCtx = foam.createSubContext({});
+    const overwriteRegister = (cls, id) => {
+      ctx.register(cls, id);
+      workerCtx.register(cls, id);
+    }
+    overwriteRegister(foam.dao.NullDAO, 'org.chromium.apis.web.WorkerDAO');
+    overwriteRegister(foam.dao.NullDAO, 'foam.dao.RestDAO');
+
+    const dao = pkg.ApiServiceDAO.create({
+      of: pkg.test.Thing,
+      baseURL: 'https://example.com/thingDAO',
+      workerRegistry: foam.box.Context.create(null, workerCtx).registry,
+    }, ctx);
+    const initialDelegate = dao.delegate;
+    dao.delegate$.sub(done);
+  });
+});

--- a/test/any/dao/worker_dao-test.es6.js
+++ b/test/any/dao/worker_dao-test.es6.js
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 'use strict';
 
-fdescribe('WorkerDAO', () => {
+describe('WorkerDAO', () => {
   let pkg;
   let ctx;
   let latestDelayedCountDAO;

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -56,6 +56,7 @@ beforeAll(function() {
   require('../../lib/confluence/metric_computer_runner.es6.js');
   require('../../lib/confluence/metric_computer_service.es6.js');
   require('../../lib/confluence/set_ops.es6.js');
+  require('../../lib/dao/api_service_dao.es6.js');
   require('../../lib/dao/dao_container.es6.js');
   require('../../lib/dao/grid_dao.es6.js');
   require('../../lib/dao/http_json_dao.es6.js');


### PR DESCRIPTION
This encapsulates the logic for first-data + fast-(cached)-data on the main thread for `api_service`. 