### PR TITLE
Server-side changes for generated.CompatData DAO

### DIFF
--- a/data/class_whitelist.json
+++ b/data/class_whitelist.json
@@ -56,6 +56,7 @@
   "foam.mlang.sink.NullSink",
   "foam.mlang.sink.Sum",
   "foam.mlang.sink.Unique",
+  "org.chromium.apis.web.generated.CompatData",
   "org.chromium.apis.web.AbstractApiCompatData",
   "org.chromium.apis.web.ApiExtractorService",
   "org.chromium.apis.web.ApiVelocityData",
@@ -76,5 +77,6 @@
   "org.chromium.apis.web.VersionedRelease",
   "org.chromium.apis.web.VersionedReleaseWebInterfaceJunction",
   "org.chromium.apis.web.VersionedWebInterface",
-  "org.chromium.apis.web.WebInterface"
+  "org.chromium.apis.web.WebInterface",
+  "org.chromium.apis.web.WorkerDAO"
 ]

--- a/lib/dao/dao_container.es6.js
+++ b/lib/dao/dao_container.es6.js
@@ -19,6 +19,7 @@ foam.CLASS({
     'as container',
     'apiVelocityDAO',
     'browserMetricsDAO',
+    'compatDAO',
     'releaseDAO',
     'releaseWebInterfaceJunctionDAO',
     'webInterfaceDAO',
@@ -28,13 +29,22 @@ foam.CLASS({
   // consolidated here to ensure that they match on the web client and front end
   // server.
   constants: {
+    // TODO(markdittmer): Drop rel/api/junction DAOs once client is fully ported
+    // to generated.CompatData model.
     RELEASE_NAME: 'releaseDAO',
     WEB_INTERFACE_NAME: 'webInterfaceDAO',
     RELEASE_WEB_INTERFACE_JUNCTION_NAME: 'releaseWebInterfaceJunctionDAO',
+    COMPAT_NAME: 'compatDAO',
+    COMPAT_MODEL_FILE_NAME: 'class:org.chromium.apis.web.generated.CompatData.json',
     API_VELOCITY_NAME: 'apiVelocityDAO',
     FAILURE_TO_SHIP_NAME: 'failureToShipDAO',
     BROWSER_SPECIFIC_NAME: 'browserSpecificDAO',
     AGGRESSIVE_REMOVAL_NAME: 'aggressiveRemovalDAO',
+
+    // Names of DAOs that the client will cache in workers.
+    CLIENT_CACHED_NAMES: {
+      'compatDAO': true,
+    },
   },
 
   properties: [
@@ -53,6 +63,12 @@ foam.CLASS({
       documentation: `DAO providing access to all browser release <--> API
           relations.`,
       name: 'releaseWebInterfaceJunctionDAO',
+    },
+    {
+      class: 'foam.dao.DAOProperty',
+      documentation: `DAO providing access to unified
+          <API, [browser support bools]> compat data model.`,
+      name: 'compatDAO',
     },
     {
       class: 'foam.dao.DAOProperty',

--- a/lib/dao/json_dao_container.es6.js
+++ b/lib/dao/json_dao_container.es6.js
@@ -51,6 +51,7 @@ foam.CLASS({
     'org.chromium.apis.web.SerializableHttpJsonDAO',
     'org.chromium.apis.web.SerializableLocalJsonDAO',
     'org.chromium.apis.web.WebInterface',
+    'org.chromium.apis.web.generated.CompatData',
   ],
   imports: [
     'error',
@@ -89,6 +90,12 @@ foam.CLASS({
       },
     },
     {
+      name: 'compatDAO',
+      factory: function() {
+        return this.getDAO(this.CompatData);
+      },
+    },
+    {
       name: 'browserMetricsDAO',
       factory: function() {
         return this.getDAO(this.BrowserMetricData);
@@ -116,6 +123,19 @@ foam.CLASS({
         return this.StubFactorySingleton.create();
       },
     },
+    {
+      class: 'Function',
+      name: 'parseURL_',
+      transient: true,
+      factory: function() {
+        if (foam.isServer) {
+          const url = require('url');
+          return url.parse.bind(url);
+        } else {
+          return str => new URL(str);
+        }
+      },
+    },
   ],
 
   methods: [
@@ -133,6 +153,7 @@ foam.CLASS({
         serializableDAO = this.SerializableLocalJsonDAO.create({
           of: cls,
           path: `${this.basename}/${cls.id}.json`,
+          path: this.parseURL_(`${this.basename}/${cls.id}.json`).pathname,
         }, ctx);
       }
       // Set propertyIndexGroups after other properties; its validation
@@ -157,14 +178,11 @@ foam.CLASS({
             data: serializableDAO,
           })),
         }, ctx),
-      });
+      }, ctx);
 
       // Perform simple query to ensure DAO is eagerly initialized.
       dao.limit(1).select().then(() => {
         this.info(`JsonDaoContainer: DAO ready (${cls.id})`);
-      }, error => {
-        this.error(`JsonDaoContainer: Initial DAO query (${cls.id}) failed:
-                       ${error}`);
       });
 
       return dao;

--- a/lib/server/server.es6.js
+++ b/lib/server/server.es6.js
@@ -26,10 +26,12 @@ foam.CLASS({
     'org.chromium.apis.web.BrowserMetricDataType',
     'org.chromium.apis.web.DAOContainer',
     'org.chromium.apis.web.ServerMode',
+    'org.chromium.apis.web.generated.CompatData',
   ],
   imports: [
     'apiVelocityDAO',
     'browserMetricsDAO',
+    'compatDAO',
     'releaseDAO',
     'releaseWebInterfaceJunctionDAO',
     'webInterfaceDAO',
@@ -71,6 +73,44 @@ foam.CLASS({
           // Non-cached does not throw, but does not get stored either.
           this.info(`CacheDAO: Bypass cache storage: ${cachedResponse.id}`);
           return Promise.resolve(cachedResponse);
+        },
+      ],
+    },
+    {
+      name: 'GeneratedClassHandler',
+      extends: 'foam.net.node.PathnameHandler',
+
+      requires: ['foam.json.Outputter'],
+
+      properties: [
+        {
+          class: 'Class',
+          name: 'of',
+        },
+        {
+          class: 'FObjectProperty',
+          of: 'foam.json.Outputter',
+          name: 'outputter',
+          factory: function() {
+            return this.Outputter.create({
+              passPropertiesByReference: false,
+              pretty: false,
+              formatDatesAsNumbers: true,
+              outputDefaultValues: false,
+              useShortNames: false,
+              strict: true,
+            });
+          },
+        },
+      ],
+
+      methods: [
+        function handle(req, res) {
+          res.setStatusCode(200);
+          res.setHeader('Content-type', 'application/json');
+          res.end(this.outputter.stringify(this.of.model_, foam.core.Model), 
+                  'utf8');
+          return true;
         },
       ],
     },
@@ -122,7 +162,6 @@ foam.CLASS({
 
   methods: [
     function start() {
-
       // Initialize predictably on start().
       this.cache_ = this.CacheDAO.create();
       this.cacheManager_ = this.LRUDAOManager.create({
@@ -141,6 +180,10 @@ foam.CLASS({
       this.addFile_('/',
                     this.path.resolve(__dirname, '../../static/index.html'));
 
+      this.router.addPathname(
+                      `/class:${this.CompatData.id}.json`,
+                      this.GeneratedClassHandler.create({of: this.CompatData}));
+
       const EQ = this.EQ.bind(this);
       const Type = this.BrowserMetricDataType;
       const TYPE = this.BrowserMetricData.TYPE;
@@ -150,6 +193,8 @@ foam.CLASS({
                        this.webInterfaceDAO);
       this.addDAORoute_(this.DAOContainer.RELEASE_WEB_INTERFACE_JUNCTION_NAME,
                        this.releaseWebInterfaceJunctionDAO);
+
+      this.addDAORoute_(this.DAOContainer.COMPAT_NAME, this.compatDAO);
 
       this.addDAORoute_(
           this.DAOContainer.FAILURE_TO_SHIP_NAME,


### PR DESCRIPTION
This exposes `/compatDAO` backed by `generated.CompatData` sourced in the usual way (i.e., same as `/releaseDAO`, `/webInterfaceDAO`, etc.). Because the code is generated, we also expose `/class:[pkg.path].generated.CompatData`, and also use it to bootstrap the `generated.CompatData` class in both front end and forked processes on the server.