### PR TITLE
ApiExtractor: Ignore only CONST_CASE constant values

### DIFF
--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -685,6 +685,9 @@ foam.CLASS({
                   this.isConstName_(name));
     },
     function isConstName_(name) {
+      // A subset of the "identifier" expression in
+      // https://heycam.github.io/webidl/#idl-grammar
+      // that includes only identifiers like "FOO" and "FOO_BAR".
       return /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/.test(name);
     },
     function dedupConcat_(opt_arr1, arr2) {

--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -678,10 +678,14 @@ foam.CLASS({
 
       const type = og.getType(nameId);
       return !(this.constantTypes.includes(type) &&
-               (og.lookupMetaData(name, id).value === 1 ||
-                // If type is boolean, value of false causes "value" to be 0;
-                // return true ignoring "value" metadata.
-                type === 'boolean'));
+                  (og.lookupMetaData(name, id).value === 1 ||
+                      // If type is boolean, value of false causes "value" to be
+                      // 0; return true ignoring "value" metadata.
+                      type === 'boolean') &&
+                  this.isConstName_(name));
+    },
+    function isConstName_(name) {
+      return /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)$/.test(name);
     },
     function dedupConcat_(opt_arr1, arr2) {
       const arr1 = opt_arr1 || [];

--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -685,7 +685,7 @@ foam.CLASS({
                   this.isConstName_(name));
     },
     function isConstName_(name) {
-      return /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)$/.test(name);
+      return /^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$/.test(name);
     },
     function dedupConcat_(opt_arr1, arr2) {
       const arr1 = opt_arr1 || [];

--- a/test/any/web_catalog/api_extractor-integration.es6.js
+++ b/test/any/web_catalog/api_extractor-integration.es6.js
@@ -92,10 +92,11 @@ describe('API extractor', function() {
           '+valueOf+': 6,
           'functionAPI': 10015,
           'InterfaceInstance': 10013,
-          'ObejectInstanceA': 10014,
+          'ObjectInstanceA': 10014,
           'property': 3,
           'constObjectProperty': 7,
-          'constantNumber': 3,
+          'constLikeNumber': 3,
+          'CONSTANT_NUMBER': 3,
         },
         '10010': {  // nonObjectLibrary
           '+toString+': 6,
@@ -270,7 +271,7 @@ describe('API extractor', function() {
           'InterfaceInstance': {
             'writable': 1,
           },
-          'ObejectInstanceA': {
+          'ObjectInstanceA': {
             'writable': 1,
           },
           'functionAPI': {
@@ -282,7 +283,10 @@ describe('API extractor', function() {
           'constObjectProperty': {
             'writable': 0,
           },
-          'constantNumber': {
+          'constLikeNumber': {
+            'value': 1,
+          },
+          'CONSTANT_NUMBER': {
             'value': 1,
           },
         },
@@ -375,9 +379,10 @@ describe('API extractor', function() {
       expect(apiCatalog.AnObjectInterface).toBeDefined();
       expect(apiCatalog.FunctionInterface.sort()).toEqual(
         ['meaningfulAPI'].sort());
-      expect(apiCatalog.ObjectLibrary.sort()).toEqual(
-        ['functionAPI', 'InterfaceInstance',
-        'ObejectInstanceA', 'property', 'constObjectProperty'].sort());
+      expect(apiCatalog.ObjectLibrary.sort()).toEqual([
+        'functionAPI', 'InterfaceInstance', 'ObjectInstanceA', 'property',
+        'constObjectProperty', 'constLikeNumber',
+      ].sort());
       expect(apiCatalog.AnObjectInterface.sort()).toEqual(
         ['protoProperty', 'meaningfulAPI'].sort());
     });
@@ -443,9 +448,10 @@ describe('API extractor', function() {
   it('only includes own properties.', function() {
     expect(apiCatalog.HiddenInterface).not.toContain('notwnProperty');
   });
-  it('filters out const primitives, but not const objects.', function() {
+  it('filters out CONST_CASE primitives, but not const objects.', function() {
     expect(apiCatalog.ObjectLibrary).toContain('property');
     expect(apiCatalog.ObjectLibrary).toContain('constObjectProperty');
-    expect(apiCatalog.ObjectLibrary).not.toContain('constantNumber');
+    expect(apiCatalog.ObjectLibrary).toContain('constLikeNumber');
+    expect(apiCatalog.ObjectLibrary).not.toContain('CONSTANT_NUMBER');
   });
 });

--- a/test/any/web_catalog/api_extractor-integration.es6.js
+++ b/test/any/web_catalog/api_extractor-integration.es6.js
@@ -96,6 +96,9 @@ describe('API extractor', function() {
           'property': 3,
           'constObjectProperty': 7,
           'constLikeNumber': 3,
+          '_CONST_LIKE_NUMBER': 3,
+          'CONST__LIKE__NUMBER': 3,
+          'CONST_LIKE_NUMBER_': 3,
           'CONSTANT_NUMBER': 3,
         },
         '10010': {  // nonObjectLibrary
@@ -286,6 +289,15 @@ describe('API extractor', function() {
           'constLikeNumber': {
             'value': 1,
           },
+          '_CONST_LIKE_NUMBER': {
+            'value': 1,
+          },
+          'CONST__LIKE__NUMBER': {
+            'value': 1,
+          },
+          'CONST_LIKE_NUMBER_': {
+            'value': 1,
+          },
           'CONSTANT_NUMBER': {
             'value': 1,
           },
@@ -381,7 +393,8 @@ describe('API extractor', function() {
         ['meaningfulAPI'].sort());
       expect(apiCatalog.ObjectLibrary.sort()).toEqual([
         'functionAPI', 'InterfaceInstance', 'ObjectInstanceA', 'property',
-        'constObjectProperty', 'constLikeNumber',
+        'constObjectProperty', 'constLikeNumber', '_CONST_LIKE_NUMBER',
+        'CONST__LIKE__NUMBER', 'CONST_LIKE_NUMBER_',
       ].sort());
       expect(apiCatalog.AnObjectInterface.sort()).toEqual(
         ['protoProperty', 'meaningfulAPI'].sort());


### PR DESCRIPTION
This further qualifies which object graph properties are ignored on the basis that they are constants. In particular, it will ignore based on the existing criteria + property-name-is-`CONST_CASE` criteria.