### PR TITLE
Blacklist interface name "a"

### DIFF
--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -203,6 +203,8 @@ foam.CLASS({
           // "window" interface stored on "Window" instead. After copying to
           // "Window", remove "window".
           'window',
+          // Accidentally shipped in Safaris 5 - 8.
+          'a',
         ];
       },
     },
@@ -237,6 +239,10 @@ foam.CLASS({
 
           // Remove processors:
           this.RemoveInterfacesProcessor.create({
+            otherURLs: [
+              // For interface name "a":
+              'https://github.com/GoogleChromeLabs/confluence/issues/299#issuecomment-391119693',
+            ],
             interfaceNames: this.blacklistInterfaces,
           }),
           this.RemoveApisProcessor.create({


### PR DESCRIPTION
Towards #299; handles interface name `a` case.