### PR TITLE
Resurrect catalog action: Export to CSV

### DIFF
--- a/lib/action.es6.js
+++ b/lib/action.es6.js
@@ -1,0 +1,29 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+require('./u2/ActionView.es6.js')
+
+foam.CLASS({
+  refines: 'foam.core.Action',
+
+  requires: [
+    'org.chromium.apis.web.ActionView'
+  ],
+
+  methods: [
+    function toE(args, X) {
+      var view = foam.u2.ViewSpec.createView({
+        class: 'org.chromium.apis.web.ActionView',
+        action: this,
+      }, args, this, X);
+
+      if (X.data$ && !(args && (args.data || args.data$))) {
+        view.data$ = X.data$;
+      }
+
+      return view;
+    },
+  ],
+});

--- a/lib/u2/ActionView.es6.js
+++ b/lib/u2/ActionView.es6.js
@@ -25,6 +25,7 @@ foam.CLASS({
 
     ^label:hover {
       background-color: rgba(255, 255, 255, 0.2);
+      cursor: pointer;
     }
 
     ^unavailable {

--- a/lib/u2/ActionView.es6.js
+++ b/lib/u2/ActionView.es6.js
@@ -27,8 +27,12 @@ foam.CLASS({
       background-color: rgba(255, 255, 255, 0.2);
     }
 
-    ^unavailable, ^disabled {
+    ^unavailable {
       display: none;
+    }
+
+    ^disabled {
+      opacity: 0.5;
     }
 
     /*

--- a/lib/u2/DAOController.es6.js
+++ b/lib/u2/DAOController.es6.js
@@ -6,11 +6,13 @@
 foam.CLASS({
   name: 'DAOController',
   package: 'org.chromium.apis.web',
+  implements: ['foam.mlang.Expressions'],
 
   exports: [
     'as data',
     'predicate',
   ],
+  imports: ['window'],
 
   properties: [
     {
@@ -35,5 +37,37 @@ foam.CLASS({
         return predicate ? data.where(predicate) : data;
       },
     },
+    {
+      class: 'Boolean',
+      documentation: 'Indicator for in-progress downloadData operation.',
+      name: 'downloadInProgress',
+    },
   ],
+
+  methods: [
+    function downloadData(ctx) {
+      this.downloadInProgress = true;
+      const props = Array.from(ctx.selected);
+      const q = this.predicate && !this.TRUE.equals(this.predicate) ?
+          this.predicate.toString() : '';
+      const dao = this.filteredDAO;
+
+      return dao.select().then(arraySink => {
+        const data = arraySink.array;
+        const id = props.map(p => p.label)
+            .concat(q ? [q] : []).join(',');
+        let hash = 19;
+        for (let i = 0; i < id.length; i++) {
+          hash = ((hash << 5) - hash) + id.charCodeAt(i);
+        }
+
+        this.downloadInProgress = false;
+
+        return {hash, data};
+      }, err => {
+        this.downloadInProgress = false;
+        throw err;
+      });
+    },
+  ]
 });

--- a/lib/u2/DAOController.es6.js
+++ b/lib/u2/DAOController.es6.js
@@ -12,7 +12,6 @@ foam.CLASS({
     'as data',
     'predicate',
   ],
-  imports: ['window'],
 
   properties: [
     {

--- a/lib/u2/DAOControllerView.es6.js
+++ b/lib/u2/DAOControllerView.es6.js
@@ -29,6 +29,7 @@ foam.CLASS({
     'selectable? as importedSelectableColumns',
     'selected? as importedSelectedColumns',
     'setTimeout',
+    'window',
   ],
   exports: [
     'selectable', // For query parser.
@@ -263,7 +264,8 @@ foam.CLASS({
               .add(searchView)
               .add(this.slot(data => {
                 return this.E('actions')
-                    .add(data.cls_.getAxiomsByClass(foam.core.Action));
+                    .add(data.cls_.getAxiomsByClass(foam.core.Action)
+                        .concat([this.EXPORT_TO_CSV]));
               }, this.data$))
               .start('span').addClass(this.myClass('columns-container'))
                   .add(this.columnsIconE)
@@ -283,24 +285,43 @@ foam.CLASS({
     {
       name: 'exportToCSV',
       label: 'Export to CSV',
-      code: function() {
-        const props = this.selected;
-        const q = this.data && this.data.predicate ?
-            this.data.predicate.toString() : '';
-        const dao = this.data.filteredDAO;
+      icon: 'download',
+      code: function(ctx) {
+        // Note: "this" bound to "this.data" because view actions operate on
+        // view's data.
+        const document = ctx.window.document;
+        const props = Array.from(ctx.selected);
+        const q = this.predicate ? this.predicate.toString() : '';
+        const dao = this.filteredDAO;
 
-        let str = '"' + props.map(p => p.label)
-            .concat(q ? ['', 'Query:', q] : []).join('","') + '",\n';
+        dao.select().then(arraySink => {
+          let str = '"' + props.map(p => p.label)
+              .concat(q ? ['', 'Query:', q] : []).join('","') + '",\n';
+          const id = str;
 
-        this.data.filteredDAO.select().then(arraySink => {
+          let hash = 19;
+          for (let i = 0; i < id.length; i++) {
+            hash = ((hash << 5) - hash) + id.charCodeAt(i);
+          }
+          const filename = `confluence_${Math.abs(hash).toString(16)}.csv`;
+
           const data = arraySink.array;
           for (const datum of data) {
             str += `"${datum.interfaceName}#${datum.apiName}",`;
             for (const prop of props) {
               str += `"${prop.f(datum) ? 'TRUE' : 'FALSE'}",`;
             }
+            str += '\n';
           }
-          str += '\n';
+
+          const csv = `data:text/csv;charset=utf-8,${str}`;
+          const href = encodeURI(csv);
+          const link = document.createElement('a');
+          link.style.display = 'none';
+          link.setAttribute('href', href);
+          link.setAttribute('download', filename);
+          document.body.appendChild(link);
+          link.click();
         });
       },
     },

--- a/lib/u2/DAOControllerView.es6.js
+++ b/lib/u2/DAOControllerView.es6.js
@@ -285,27 +285,21 @@ foam.CLASS({
     {
       name: 'exportToCSV',
       label: 'Export to CSV',
-      icon: 'download',
+      icon: 'save_alt',
+      // For isEnabled and code: "this" bound to "this.data" because view
+      // actions operate on view's data. Params on isEnabled bound to same-name
+      // params on data model (DAOController).
+      isEnabled: function(downloadInProgress) { return !downloadInProgress; },
       code: function(ctx) {
-        // Note: "this" bound to "this.data" because view actions operate on
-        // view's data.
         const document = ctx.window.document;
+        const q = ctx.query;
         const props = Array.from(ctx.selected);
-        const q = this.predicate ? this.predicate.toString() : '';
-        const dao = this.filteredDAO;
 
-        dao.select().then(arraySink => {
-          let str = '"' + props.map(p => p.label)
-              .concat(q ? ['', 'Query:', q] : []).join('","') + '",\n';
-          const id = str;
-
-          let hash = 19;
-          for (let i = 0; i < id.length; i++) {
-            hash = ((hash << 5) - hash) + id.charCodeAt(i);
-          }
+        this.downloadData(ctx).then(({hash, data}) => {
           const filename = `confluence_${Math.abs(hash).toString(16)}.csv`;
 
-          const data = arraySink.array;
+          let str = '"' + props.map(p => p.label)
+              .concat(q ? ['', 'Query:', q] : []).join('","') + '",\n';
           for (const datum of data) {
             str += `"${datum.interfaceName}#${datum.apiName}",`;
             for (const prop of props) {

--- a/lib/u2/DAOControllerView.es6.js
+++ b/lib/u2/DAOControllerView.es6.js
@@ -136,7 +136,7 @@ foam.CLASS({
       class: 'FObjectArray',
       of: 'foam.core.Property',
       name: 'selectable',
-      documentation: `The properties that the user can select for rendering in 
+      documentation: `The properties that the user can select for rendering in
           the DAO table view.`,
       final: true,
       factory: function() {
@@ -179,7 +179,7 @@ foam.CLASS({
     },
     {
       class: 'FObjectArray',
-      
+
       of: 'foam.core.Property',
       name: 'columns',
       factory: function() {
@@ -276,6 +276,33 @@ foam.CLASS({
               .entity('nbsp').add('/').entity('nbsp')
               .add(this.total_$)
           .end();
+    },
+  ],
+
+  actions: [
+    {
+      name: 'exportToCSV',
+      label: 'Export to CSV',
+      code: function() {
+        const props = this.selected;
+        const q = this.data && this.data.predicate ?
+            this.data.predicate.toString() : '';
+        const dao = this.data.filteredDAO;
+
+        let str = '"' + props.map(p => p.label)
+            .concat(q ? ['', 'Query:', q] : []).join('","') + '",\n';
+
+        this.data.filteredDAO.select().then(arraySink => {
+          const data = arraySink.array;
+          for (const datum of data) {
+            str += `"${datum.interfaceName}#${datum.apiName}",`;
+            for (const prop of props) {
+              str += `"${prop.f(datum) ? 'TRUE' : 'FALSE'}",`;
+            }
+          }
+          str += '\n';
+        });
+      },
     },
   ],
 

--- a/lib/web_apis/api_compat_data.es6.js
+++ b/lib/web_apis/api_compat_data.es6.js
@@ -5,6 +5,7 @@
 
 require('../object.es6.js');
 require('../property.es6.js');
+require('../action.es6.js');
 require('./release.es6.js');
 
 foam.CLASS({

--- a/main/app.es6.js
+++ b/main/app.es6.js
@@ -10,6 +10,7 @@ require('@uirouter/angularjs');
 // Refinements before models.
 require('../lib/object.es6.js');
 require('../lib/property.es6.js');
+require('../lib/action.es6.js');
 
 require('../lib/web_apis/api_compat_data.es6.js');
 require('../lib/web_apis/release.es6.js');

--- a/main/relational_to_compat.es6.js
+++ b/main/relational_to_compat.es6.js
@@ -12,6 +12,7 @@ require('foam2');
 
 require('../lib/object.es6.js');
 require('../lib/property.es6.js');
+require('../lib/action.es6.js');
 
 require('../lib/dao/http_json_dao.es6.js');
 require('../lib/dao/json_dao_container.es6.js');

--- a/main/ui_test.es6.js
+++ b/main/ui_test.es6.js
@@ -11,6 +11,7 @@
 // Refinements before models.
 require('../lib/object.es6.js');
 require('../lib/property.es6.js');
+require('../lib/action.es6.js');
 
 require('../lib/u2/ActionView.es6.js');
 require('../lib/u2/DAOController.es6.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -6980,7 +6980,7 @@
       }
     },
     "foam2": {
-      "version": "git://github.com/foam-framework/foam2.git#c2a437ec6c299a2b6f3b78981035f133f5f5f77b"
+      "version": "git://github.com/foam-framework/foam2.git#e46345c36225692625f9f0a91ff60d19141ee1f9"
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -9510,8 +9510,7 @@
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
               "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "json-schema": {
               "version": "0.2.3",

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -36,6 +36,7 @@ beforeAll(function() {
   // Load refinements before anything else.
   require('../../lib/object.es6.js');
   require('../../lib/property.es6.js');
+  require('../../lib/action.es6.js');
 
   if (foam.isServer) requireNodeCode();
   else requireBrowserCode();


### PR DESCRIPTION
Design notes:

- DAOController manages `select()` to fetch data
- DAOControllerView owns action to package and download data in CSV format
- Refine `foam.core.Action` to instantiate `org.chromium.apis.web.ActionView` when constructing U2 Element for a `foam.core.Action`
- Disabled actions are "greyed out", not hidden entirely