### PR TITLE
ApiCount: Use CompatData rather than Junction table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 .web_coverage
 node_modules
 static/bundle/
+data/json/*.json
+data/object-graph/*.json
+.vscode

--- a/lib/confluence/api_count.es6.js
+++ b/lib/confluence/api_count.es6.js
@@ -59,7 +59,9 @@ foam.CLASS({
           sequence.`,
       code: function(release) {
         this.info(`Computing ApiCount for single release ${release.id}`);
-        return release.interfaces.dao.select(this.COUNT())
+        const prop = this.CompatData.getAxiomsByClass(this.CompatProperty)
+            .filter(p => p.release.equals(release))[0];
+        return this.compatDAO.where(this.EQ(prop, true)).select(this.COUNT())
             .then(count => {
               this.info(`Computed ApiCount for single release ${release.id}`);
               return this.apiCountDAO.put(this.ApiCountData.create({

--- a/lib/confluence/api_count.es6.js
+++ b/lib/confluence/api_count.es6.js
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 'use strict';
 
+require('../web_apis/api_compat_data.es6.js');
 require('../web_apis/release.es6.js');
 require('./api_count_data.es6');
-require('./set_ops.es6.js');
 
 foam.CLASS({
   name: 'ApiCount',
@@ -21,12 +21,14 @@ foam.CLASS({
     'foam.dao.ArraySink',
     'foam.dao.EasyDAO',
     'org.chromium.apis.web.ApiCountData',
+    'org.chromium.apis.web.generated.CompatData',
+    'org.chromium.apis.web.CompatProperty',
     'org.chromium.apis.web.Release',
   ],
   imports: [
     'apiCountDAO',
+    'compatDAO',
     'info',
-    'releaseDAO',
   ],
 
   methods: [
@@ -75,15 +77,23 @@ foam.CLASS({
           "prev" as previous browser release.`,
       code: function(prev, next) {
         this.info(`Computing ApiCount for release pair ${prev.id}, ${next.id}`);
+        const props = this.CompatData.getAxiomsByClass(this.CompatProperty);
+        const prevProp = props.filter(p => p.release.equals(prev));
+        const nextProp = props.filter(p => p.release.equals(next));
         return Promise.all([
           // [0]: API count.
-          next.interfaces.dao.select(this.COUNT()),
+          this.compatDAO.where(this.EQ(nextProp, true))
+              .select(this.COUNT()),
           // [1]: Removed count.
-          prev.interfaces.dao.select(
-              this.SET_MINUS(next.interfaces.dao, this.COUNT())),
+          this.compatDAO.where(this.AND(
+                  this.EQ(prevProp, true),
+                  this.EQ(nextProp, false)))
+              .select(this.COUNT()),
           // [2]: Added count.
-          next.interfaces.dao.select(
-              this.SET_MINUS(prev.interfaces.dao, this.COUNT())),
+          this.compatDAO.where(this.AND(
+                this.EQ(prevProp, false),
+                this.EQ(nextProp, true)))
+            .select(this.COUNT()),
         ]).then(results => {
           this.info(`Computed ApiCount for release pair ${prev.id}, ${next.id}`);
           return this.apiCountDAO.put(this.ApiCountData.create({

--- a/lib/confluence/api_count.es6.js
+++ b/lib/confluence/api_count.es6.js
@@ -84,29 +84,28 @@ foam.CLASS({
         let removedApis = 0;
         let newApis = 0;
         return this.compatDAO.where(this.OR(
-          this.AND(
-          this.EQ(prevProp, true),
-          this.EQ(nextProp, false)),
-          this.EQ(nextProp, true)
-        )).select().then(arraySink => {
-          const apis = arraySink.array;
-          for (const api of apis) {
-            if (!nextProp.f(api)) removedApis++;
-            else totalApis++;
-            if (!prevProp.f(api)) newApis++;
-          }
+            this.AND(
+                this.EQ(prevProp, true),
+                this.EQ(nextProp, false)),
+            this.EQ(nextProp, true))).select().then(arraySink => {
+              const apis = arraySink.array;
+              for (const api of apis) {
+                if (!nextProp.f(api)) removedApis++;
+                else totalApis++;
+                if (!prevProp.f(api)) newApis++;
+              }
 
-          this.info(`Computed ApiCount for release pair ${prev.id}, ${next.id}`);
-          return this.apiCountDAO.put(this.ApiCountData.create({
-            releaseDate: next.releaseDate,
-            browserName: next.browserName,
-            currRelease: next,
-            prevRelease: prev,
-            totalApis,
-            removedApis,
-            newApis,
-          }));
-        });
+              this.info(`Computed ApiCount for release pair ${prev.id}, ${next.id}`);
+              return this.apiCountDAO.put(this.ApiCountData.create({
+                releaseDate: next.releaseDate,
+                browserName: next.browserName,
+                currRelease: next,
+                prevRelease: prev,
+                totalApis,
+                removedApis,
+                newApis,
+              }));
+            });
       },
     },
   ],

--- a/lib/confluence/api_count.es6.js
+++ b/lib/confluence/api_count.es6.js
@@ -78,32 +78,33 @@ foam.CLASS({
       code: function(prev, next) {
         this.info(`Computing ApiCount for release pair ${prev.id}, ${next.id}`);
         const props = this.CompatData.getAxiomsByClass(this.CompatProperty);
-        const prevProp = props.filter(p => p.release.equals(prev));
-        const nextProp = props.filter(p => p.release.equals(next));
-        return Promise.all([
-          // [0]: API count.
-          this.compatDAO.where(this.EQ(nextProp, true))
-              .select(this.COUNT()),
-          // [1]: Removed count.
-          this.compatDAO.where(this.AND(
-                  this.EQ(prevProp, true),
-                  this.EQ(nextProp, false)))
-              .select(this.COUNT()),
-          // [2]: Added count.
-          this.compatDAO.where(this.AND(
-                this.EQ(prevProp, false),
-                this.EQ(nextProp, true)))
-            .select(this.COUNT()),
-        ]).then(results => {
+        const prevProp = props.filter(p => p.release.equals(prev))[0];
+        const nextProp = props.filter(p => p.release.equals(next))[0];
+        let totalApis = 0;
+        let removedApis = 0;
+        let newApis = 0;
+        return this.compatDAO.where(this.OR(
+          this.AND(
+          this.EQ(prevProp, true),
+          this.EQ(nextProp, false)),
+          this.EQ(nextProp, true)
+        )).select().then(arraySink => {
+          const apis = arraySink.array;
+          for (const api of apis) {
+            if (!nextProp.f(api)) removedApis++;
+            else totalApis++;
+            if (!prevProp.f(api)) newApis++;
+          }
+
           this.info(`Computed ApiCount for release pair ${prev.id}, ${next.id}`);
           return this.apiCountDAO.put(this.ApiCountData.create({
             releaseDate: next.releaseDate,
             browserName: next.browserName,
             currRelease: next,
             prevRelease: prev,
-            totalApis: results[0].value,
-            removedApis: results[1].value,
-            newApis: results[2].value,
+            totalApis,
+            removedApis,
+            newApis,
           }));
         });
       },

--- a/lib/confluence/api_count.es6.js
+++ b/lib/confluence/api_count.es6.js
@@ -60,7 +60,7 @@ foam.CLASS({
       code: function(release) {
         this.info(`Computing ApiCount for single release ${release.id}`);
         const prop = this.CompatData.getAxiomsByClass(this.CompatProperty)
-            .filter(p => p.release.equals(release))[0];
+            .find(p => p.release.equals(release));
         return this.compatDAO.where(this.EQ(prop, true)).select(this.COUNT())
             .then(count => {
               this.info(`Computed ApiCount for single release ${release.id}`);
@@ -80,8 +80,8 @@ foam.CLASS({
       code: function(prev, next) {
         this.info(`Computing ApiCount for release pair ${prev.id}, ${next.id}`);
         const props = this.CompatData.getAxiomsByClass(this.CompatProperty);
-        const prevProp = props.filter(p => p.release.equals(prev))[0];
-        const nextProp = props.filter(p => p.release.equals(next))[0];
+        const prevProp = props.find(p => p.release.equals(prev));
+        const nextProp = props.find(p => p.release.equals(next));
         let totalApis = 0;
         let removedApis = 0;
         let newApis = 0;

--- a/lib/confluence/metric_computer_service.es6.js
+++ b/lib/confluence/metric_computer_service.es6.js
@@ -65,6 +65,7 @@ foam.CLASS({
   requires: [
     'org.chromium.apis.web.ApiCountData',
     'org.chromium.apis.web.BrowserMetricData',
+    'org.chromium.apis.web.generated.CompatData',
     'org.chromium.apis.web.LocalJsonDAO',
     'org.chromium.apis.web.Release',
     'org.chromium.apis.web.ReleaseWebInterfaceJunction',
@@ -105,6 +106,14 @@ foam.CLASS({
       transient: true,
       factory: function() {
         return this.getDAO_(this.ReleaseWebInterfaceJunction);
+      },
+    },
+    {
+      class: 'foam.dao.DAOProperty',
+      name: 'compatDAO',
+      transient: true,
+      factory: function() {
+        return this.getDAO_(this.CompatData);
       },
     },
     {
@@ -203,6 +212,7 @@ foam.CLASS({
         this.container.webInterfaceDAO = this.webInterfaceDAO;
         this.container.releaseWebInterfaceJunctionDAO =
             this.releaseWebInterfaceJunctionDAO;
+        this.container.compatDAO = this.compatDAO;
 
         // Bind fresh output DAOs to container.
         this.browserMetricsDAO = this.container.browserMetricsDAO =

--- a/main/forkScript.js
+++ b/main/forkScript.js
@@ -33,7 +33,7 @@ const pkg = org.chromium.apis.web;
 
 const logger = foam.log.ConsoleLogger.create();
 
-const compatClassFile = 'class:org.chromium.apis.web.generated.CompatData.json';
+const compatClassFile = pkg.DAOContainer.COMPAT_MODEL_FILE_NAME;
 
 // TODO(markdittmer): This should be local or remote based on param passed to
 // parent. It should be forwarded to forkScript invocation.

--- a/main/json_to_metrics.es6.js
+++ b/main/json_to_metrics.es6.js
@@ -8,11 +8,13 @@ const path = require('path');
 global.FOAM_FLAGS = {gcloud: true};
 require('foam2');
 
+require('../lib/compat.es6.js');
 require('../lib/confluence/api_count_data.es6.js');
 require('../lib/confluence/browser_metric_data.es6.js');
 require('../lib/confluence/metric_computer_runner.es6.js');
 require('../lib/dao/dao_container.es6.js');
 require('../lib/dao/local_json_dao.es6.js');
+require('../lib/web_apis/api_compat_data.es6.js');
 require('../lib/web_apis/release.es6.js');
 require('../lib/web_apis/release_interface_relationship.es6.js');
 require('../lib/web_apis/web_interface.es6.js');
@@ -30,67 +32,79 @@ const logger = foam.log.ConsoleLogger.create(null, foam.createSubContext({
 
 let container = pkg.DAOContainer.create(null, logger);
 
-container.releaseDAO = pkg.LocalJsonDAO.create({
-  of: pkg.Release,
-  path: `${__dirname}/../data/json/${pkg.Release.id}.json`
-}, container);
-container.browserMetricsDAO = foam.dao.MDAO.create({
-  of: pkg.BrowserMetricData,
-}, container);
-container.apiCountDAO = foam.dao.MDAO.create({
-  of: pkg.ApiCountData,
-}, container);
+const compatClassURL = `file://${__dirname}/../data/json/${pkg.DAOContainer.COMPAT_MODEL_FILE_NAME}`;
+pkg.ClassGenerator.create({
+  classURL: compatClassURL,
+}).generateClass().then(CompatData => {
+  container.releaseDAO = pkg.LocalJsonDAO.create({
+    of: pkg.Release,
+    path: `${__dirname}/../data/json/${pkg.Release.id}.json`
+  }, container);
+  container.compatDAO = pkg.LocalJsonDAO.create({
+    of: CompatData,
+    path: `${__dirname}/../data/json/${CompatData.id}.json`
+  }, container);
+  container.browserMetricsDAO = foam.dao.MDAO.create({
+    of: pkg.BrowserMetricData,
+  }, container);
+  container.apiCountDAO = foam.dao.MDAO.create({
+    of: pkg.ApiCountData,
+  }, container);
 
-const runner = pkg.MetricComputerRunner.create(null, container);
+  const runner = pkg.MetricComputerRunner.create({
+    // TODO(markdittmer): Testing only.
+    metricComputerTypes: [pkg.MetricComputerType.API_COUNT],
+  }, container);
 
-//
-// Compute data, then store it in data/json/{class}.json
-//
+  //
+  // Compute data, then store it in data/json/{class}.json
+  //
 
-runner.run().then(() => {
-  const outputter = foam.json.Outputter.create({
-    pretty: false,
-    formatDatesAsNumbers: true,
-    outputDefaultValues: false,
-    useShortNames: false,
-    strict: true,
-  });
-  function store(basename, arraySink) {
-    const cls = arraySink.of || arraySink.array[0] ? arraySink.array[0].cls_ :
-        foam.core.FObject;
-    logger.info(`Storing ${cls.id} as ${basename}`);
-    return new Promise((resolve, reject) => {
-      require('fs').writeFile(
-        `${__dirname}/../data/json/${basename}.json`,
-        outputter.stringify(arraySink.array, cls),
-        error => {
-          if (error) {
-            logger.error(`Error storing ${cls.id} as ${basename}`, error);
-            reject(error);
-          } else {
-            logger.info(`Stored ${cls.id} as ${basename}`, error);
-            resolve();
-          }
-        });
+  return runner.run().then(() => {
+    const outputter = foam.json.Outputter.create({
+      pretty: false,
+      formatDatesAsNumbers: true,
+      outputDefaultValues: false,
+      useShortNames: false,
+      strict: true,
     });
-  }
+    function store(basename, arraySink) {
+      const cls = arraySink.of || arraySink.array[0] ? arraySink.array[0].cls_ :
+          foam.core.FObject;
+      logger.info(`Storing ${cls.id} as ${basename}`);
+      return new Promise((resolve, reject) => {
+        require('fs').writeFile(
+          `${__dirname}/../data/json/${basename}.json`,
+          outputter.stringify(arraySink.array, cls),
+          error => {
+            if (error) {
+              logger.error(`Error storing ${cls.id} as ${basename}`, error);
+              reject(error);
+            } else {
+              logger.info(`Stored ${cls.id} as ${basename}`, error);
+              resolve();
+            }
+          });
+      });
+    }
 
-  return Promise.all([
-    container.browserMetricsDAO
-        .orderBy(E.THEN_BY(pkg.BrowserMetricData.TYPE,
-                           E.THEN_BY(pkg.BrowserMetricData.BROWSER_NAME,
-                                     pkg.BrowserMetricData.DATE)))
-        .select().then(store.bind(this, pkg.BrowserMetricData.id)),
-    container.apiCountDAO
-        .orderBy(E.THEN_BY(pkg.ApiCountData.BROWSER_NAME,
-                           pkg.ApiCountData.RELEASE_DATE))
-        .select().then(store.bind(this, pkg.ApiCountData.id)),
-  ]);
-}).then(() => {
-  logger.info(`API JSON => Metrics JSON complete`);
-  require('process').exit(0);
+    return Promise.all([
+      container.browserMetricsDAO
+          .orderBy(E.THEN_BY(pkg.BrowserMetricData.TYPE,
+                            E.THEN_BY(pkg.BrowserMetricData.BROWSER_NAME,
+                                      pkg.BrowserMetricData.DATE)))
+          .select().then(store.bind(this, pkg.BrowserMetricData.id)),
+      container.apiCountDAO
+          .orderBy(E.THEN_BY(pkg.ApiCountData.BROWSER_NAME,
+                            pkg.ApiCountData.RELEASE_DATE))
+          .select().then(store.bind(this, pkg.ApiCountData.id)),
+    ]);
+  }).then(() => {
+    logger.info(`API JSON => Metrics JSON complete`);
+    require('process').exit(0);
+  });
 }).catch(error => {
   logger.error(`Error: ${error}
-                     EXITING`);
+                    EXITING`);
   require('process').exit(1);
 });

--- a/main/json_to_metrics.es6.js
+++ b/main/json_to_metrics.es6.js
@@ -96,7 +96,7 @@ pkg.ClassGenerator.create({
           .select().then(store.bind(this, pkg.BrowserMetricData.id)),
       container.apiCountDAO
           .orderBy(E.THEN_BY(pkg.ApiCountData.BROWSER_NAME,
-                            pkg.ApiCountData.RELEASE_DATE))
+                             pkg.ApiCountData.RELEASE_DATE))
           .select().then(store.bind(this, pkg.ApiCountData.id)),
     ]);
   }).then(() => {

--- a/test/any/confluence/api_count-test.es6.js
+++ b/test/any/confluence/api_count-test.es6.js
@@ -23,13 +23,13 @@ describe('ApiCount', () => {
   beforeEach(() => {
     gen =
         foam.lookup('org.chromium.apis.web.AbstractCompatClassGenerator')
-        .create()
+        .create();
   });
 
   const init = releaseSpecs => {
     // Register custom CompatData before looking up classes and instantiating
     // instances.
-    CompatData = global.defineGeneratedCompatData(releaseSpecs);
+    CompatData = global.defineGeneratedCompatData(gen, releaseSpecs);
 
     Release = foam.lookup('org.chromium.apis.web.Release');
     ApiCountData = foam.lookup('org.chromium.apis.web.ApiCountData');

--- a/test/any/confluence/api_count-test.es6.js
+++ b/test/any/confluence/api_count-test.es6.js
@@ -29,22 +29,7 @@ describe('ApiCount', () => {
   const init = releaseSpecs => {
     // Register custom CompatData before looking up classes and instantiating
     // instances.
-    foam.CLASS({
-      name: 'CompatData',
-      package: 'org.chromium.apis.web.test',
-      extends: 'org.chromium.apis.web.AbstractApiCompatData',
-
-      properties: releaseSpecs.map(r => {
-        return {
-          class: 'org.chromium.apis.web.CompatProperty',
-          release: r,
-          name: gen.propertyNameFromRelease(r),
-          label: gen.propertyLabelFromRelease(r),
-        };
-      }),
-    });
-    foam.register(org.chromium.apis.web.test.CompatData, 'org.chromium.apis.web.generated.CompatData');
-    CompatData = foam.lookup('org.chromium.apis.web.generated.CompatData');
+    CompatData = global.defineGeneratedCompatData(releaseSpecs);
 
     Release = foam.lookup('org.chromium.apis.web.Release');
     ApiCountData = foam.lookup('org.chromium.apis.web.ApiCountData');

--- a/test/any/confluence/runner-helper.es6.js
+++ b/test/any/confluence/runner-helper.es6.js
@@ -17,6 +17,7 @@ beforeAll(() => {
         releaseWebInterfaceJunctionDAO: ctx.releaseWebInterfaceJunctionDAO,
         browserMetricsDAO: ctx.browserMetricsDAO,
         apiCountDAO: ctx.apiCountDAO,
+        compatDAO: ctx.compatDAO,
       }, ctx),
     }, args);
     return pkg.MetricComputerRunner.create(finalArgs, ctx);

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -72,7 +72,7 @@ beforeAll(function(done) {
   const pkg = org.chromium.apis.web;
 
   const compatClassFile = pkg.DAOContainer.COMPAT_MODEL_FILE_NAME;
-  const compatClassURL = `file://${__dirname}/../../data/json/${compatClassFile}`;
+  const compatClassURL = `file://${__dirname}/../data/json/${compatClassFile}`;
   pkg.ClassGenerator.create({
     classURL: compatClassURL,
   }).generateClass().then(done);

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -32,7 +32,7 @@ function requireNodeCode() {
   require('../../lib/web_catalog/object_graph_importer.es6.js');
 }
 
-beforeAll(function() {
+beforeAll(function(done) {
   // Load refinements before anything else.
   require('../../lib/object.es6.js');
   require('../../lib/property.es6.js');
@@ -69,4 +69,11 @@ beforeAll(function() {
   require('../../lib/web_apis/version_history.es6.js');
   require('../../lib/web_apis/web_interface.es6.js');
   require('../../lib/web_catalog/api_extractor.es6.js');
+  const pkg = org.chromium.apis.web;
+
+  const compatClassFile = pkg.DAOContainer.COMPAT_MODEL_FILE_NAME;
+  const compatClassURL = `file://${__dirname}/../../data/json/${compatClassFile}`;
+  pkg.ClassGenerator.create({
+    classURL: compatClassURL,
+  }).generateClass().then(done);
 });

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -32,7 +32,7 @@ function requireNodeCode() {
   require('../../lib/web_catalog/object_graph_importer.es6.js');
 }
 
-beforeAll(function(done) {
+beforeAll(function() {
   // Load refinements before anything else.
   require('../../lib/object.es6.js');
   require('../../lib/property.es6.js');
@@ -71,9 +71,5 @@ beforeAll(function(done) {
   require('../../lib/web_catalog/api_extractor.es6.js');
   const pkg = org.chromium.apis.web;
 
-  const compatClassFile = pkg.DAOContainer.COMPAT_MODEL_FILE_NAME;
-  const compatClassURL = `file://${__dirname}/../data/${compatClassFile}`;
-  pkg.ClassGenerator.create({
-    classURL: compatClassURL,
-  }).generateClass().then(done);
+  foam.CLASS(require('../data/class:org.chromium.apis.web.generated.CompatData.json'));
 });

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -72,7 +72,7 @@ beforeAll(function(done) {
   const pkg = org.chromium.apis.web;
 
   const compatClassFile = pkg.DAOContainer.COMPAT_MODEL_FILE_NAME;
-  const compatClassURL = `file://${__dirname}/../data/json/${compatClassFile}`;
+  const compatClassURL = `file://${__dirname}/../data/${compatClassFile}`;
   pkg.ClassGenerator.create({
     classURL: compatClassURL,
   }).generateClass().then(done);

--- a/test/any/generated_compat_data-helper.es6.js
+++ b/test/any/generated_compat_data-helper.es6.js
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 'use strict';
 
-global.defineGeneratedCompatData = releaseSpecs => {
+global.defineGeneratedCompatData = (gen, releaseSpecs) => {
   // Register custom CompatData before looking up classes and instantiating
   // instances.
   foam.CLASS({

--- a/test/any/generated_compat_data-helper.es6.js
+++ b/test/any/generated_compat_data-helper.es6.js
@@ -1,0 +1,26 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+global.defineGeneratedCompatData = releaseSpecs => {
+  // Register custom CompatData before looking up classes and instantiating
+  // instances.
+  foam.CLASS({
+    name: 'CompatData',
+    package: 'org.chromium.apis.web.test',
+    extends: 'org.chromium.apis.web.AbstractApiCompatData',
+
+    properties: releaseSpecs.map(r => {
+      return {
+        class: 'org.chromium.apis.web.CompatProperty',
+        release: r,
+        name: gen.propertyNameFromRelease(r),
+        label: gen.propertyLabelFromRelease(r),
+      };
+    }),
+  });
+  foam.register(org.chromium.apis.web.test.CompatData,
+      'org.chromium.apis.web.generated.CompatData');
+  return foam.lookup('org.chromium.apis.web.generated.CompatData');
+};

--- a/test/any/web_apis/container-helper.es6.js
+++ b/test/any/web_apis/container-helper.es6.js
@@ -18,6 +18,8 @@ beforeAll(function() {
     var WebInterface = ctx.lookup('org.chromium.apis.web.WebInterface');
     var ReleaseWebInterfaceJunction =
         ctx.lookup('org.chromium.apis.web.ReleaseWebInterfaceJunction');
+    var CompatData =
+        ctx.lookup('org.chromium.apis.web.generated.CompatData');
     var BrowserMetricData =
         ctx.lookup('org.chromium.apis.web.BrowserMetricData');
     var ApiCountData =
@@ -37,6 +39,11 @@ beforeAll(function() {
       releaseWebInterfaceJunctionDAO: EasyDAO.create({
         name: 'releaseWebInterfaceJunctionDAO',
         of: ReleaseWebInterfaceJunction,
+        daoType: 'MDAO',
+      }),
+      compatDAO: EasyDAO.create({
+        name: 'compatDAO',
+        of: CompatData,
         daoType: 'MDAO',
       }),
       browserMetricsDAO: EasyDAO.create({


### PR DESCRIPTION
Compute `ApiCount` metric using `CompatData` wide table rows instead of `Junction` Release<-->API relations. This should ensure that client views are constructed using the same query as the metric computer.