### PR TITLE
Ellipsis + pop-out-on-hover on catalog cols (in addition to row IDs)

### DIFF
--- a/lib/u2/ScrollDAOTable.es6.js
+++ b/lib/u2/ScrollDAOTable.es6.js
@@ -45,6 +45,7 @@ foam.CLASS({
       display: flex;
       min-height: 0;
       justify-content: space-between;
+      align-items: center;
     }
 
     ^scroll-container {

--- a/lib/u2/ScrollDAOTable.es6.js
+++ b/lib/u2/ScrollDAOTable.es6.js
@@ -37,13 +37,11 @@ foam.CLASS({
       font-weight: bold;
       height: 50px;
       box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.14), 0 2px 1px -2px rgba(0, 0, 0, 0.2);
+      position: relative;
     }
 
     ^ col-head {
       overflow: hidden;
-      white-space: nowrap;
-      text-overflow: ellipsis;
-      margin: auto 5px;
       display: flex;
       min-height: 0;
       justify-content: space-between;
@@ -54,30 +52,58 @@ foam.CLASS({
       flex-grow: 1;
     }
 
-    ^ span, ^ .id {
+    ^ .id {
+      overflow: hidden;
+    }
+
+    ^ .ellipsis {
+      height: 100%;
+      color: rgba(0, 0, 0, 0.8);
+      display: flex;
+      align-items: center;
+      margin: auto 0;
+      padding: 0 5px;
+      overflow: hidden;
+    }
+
+    ^ .ellipsis span {
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
-      margin: auto 5px;
     }
 
-    ^ .id .overlay {
+    ^ .overlay {
       display: none;
       position: absolute;
-      top: 0;
-      left: 0;
+      margin: auto 0;
+      padding: 0 5px;
     }
 
     ^ li:hover .id {
      color: transparent;
     }
 
-    ^ li:hover .id .overlay {
+    ^ li:hover .overlay, ^ col-head:hover .overlay {
       height: 100%;
       color: rgba(0, 0, 0, 0.8);
-      background-color: rgba(255, 255, 255, 0.6);
       display: flex;
       align-items: center;
+    }
+
+    ^ li:hover .overlay {
+      background-color: rgba(255, 255, 255, 0.6);
+    }
+
+    ^ col-head, ^ col-head:hover .overlay {
+      background-color: inherit;
+    }
+
+    ^ col-head:hover .overlay {
+      z-index: 3;
+    }
+
+    ^ li:hover .ellipsis, ^ col-head:hover .ellipsis {
+      visibility: hidden;
     }
 
     ^icon {
@@ -188,7 +214,8 @@ foam.CLASS({
             return this.E('col-heads')
                 .forEach(columns, function(col) {
                   let ret = this.start('col-head')
-                      .start('span').add(col.label).end();
+                      .start('div').addClass('ellipsis').start('span').add(col.label).end().end()
+                      .start('div').addClass('overlay').add(col.label).end();
                   if (removeColumn && col.name !== 'id') {
                     ret.start('i').addClass('material-icons')
                         .addClass(self.myClass('icon'))

--- a/lib/web_apis/api_compat_data.es6.js
+++ b/lib/web_apis/api_compat_data.es6.js
@@ -106,8 +106,8 @@ foam.CLASS({
         const textValue = foam.String.isInstance(value) ? value : '&nbsp;';
         return `
           <div class="id">
-            ${textValue}
-            <div class="overlay"><span>${textValue}</span></div>
+            <div class="overlay">${textValue}</div>
+            <div class="ellipsis"><span>${textValue}</span></div>
           </div>
         `;
       },


### PR DESCRIPTION
To test:

Go to `/#!/catalog?releases=%5B"Chrome_40.0.2214.93_Windows_10.0","Chrome_41.0.2272.89_Windows_10.0","Chrome_42.0.2311.135_Windows_10.0","Chrome_43.0.2357.81_Windows_10.0","Chrome_44.0.2403.89_Windows_10.0","Chrome_45.0.2454.85_Windows_10.0","Chrome_46.0.2490.71_Windows_10.0","Chrome_47.0.2526.73_Windows_10.0","Chrome_48.0.2564.97_Windows_10.0","Chrome_49.0.2623.75_Windows_10.0","Chrome_50.0.2661.75_Windows_10.0","Chrome_51.0.2704.79_Windows_10.0","Chrome_52.0.2743.82_Windows_10.0","Chrome_53.0.2785.113_Windows_10.0","Safari_11.0.3_OSX_10.13.3","Edge_16.16299_Windows_10.0","Firefox_56.0_Windows_10.0"%5D&q="notin:chr53.0.2785win10%20in:fir56win10%20in:edg16win10%20in:saf11.0osx10.13%20(count:4%20or%20count:5%20or%20count:6%20or%20count:7%20or%20count:8%20or%20count:9%20or%20count:10%20or%20count:11%20or%20count:12%20or%20count:13%20or%20count:14%20or%20count:15%20or%20count:16%20or%20count:17)"`

... or any crowded catalog view.

Hover over column labels to see ellipsis turn into overlay full text.