### PR TITLE
Refactor 'mode' for fetching data from data source

### DIFF
--- a/lib/confluence/metric_computer_runner.es6.js
+++ b/lib/confluence/metric_computer_runner.es6.js
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 'use strict';
 
+require('../data_source.es6.js');
+require('../fork.es6.js');
 require('../web_apis/release.es6.js');
 require('./metric_computer_service.es6.js');
 
@@ -103,13 +105,13 @@ foam.CLASS({
   name: 'MetricComputerRunner',
   package: 'org.chromium.apis.web',
   extends: 'org.chromium.apis.web.AbstractMetricComputerRunner',
+  implements: ['org.chromium.apis.web.ForkBoxFactory'],
 
   requires: [
     'foam.box.BoxRegistry',
     'foam.box.BroadcastRegistry',
     'foam.box.Context',
     'foam.box.SkeletonBox',
-    'foam.box.node.ForkBox',
     'foam.core.StubFactorySingleton',
     'foam.dao.ArraySink',
     'org.chromium.apis.web.MetricComputerService',
@@ -118,6 +120,12 @@ foam.CLASS({
   ],
 
   properties: [
+    {
+      class: 'Enum',
+      of: 'org.chromium.apis.web.DataSource',
+      name: 'mode',
+      required: true,
+    },
     {
       class: 'FObjectArray',
       of: 'org.chromium.apis.web.MetricComputerType',
@@ -174,6 +182,8 @@ foam.CLASS({
       of: 'foam.box.Context',
       name: 'metricsContext_',
       factory: function() {
+        this.validate();
+
         let ctx = this.Context.create({
           unsafe: false,
           classWhitelist: require('../../data/class_whitelist.json'),
@@ -185,11 +195,7 @@ foam.CLASS({
         for (let i = 0; i < numWorkers; i++) {
           // Stub BoxRegistry interface over box addressed to new fork.
           workers[i] = this.stubFactory.get(this.BoxRegistry).create({
-            delegate: this.ForkBox.create({
-              critical: true,
-              nodeParams:  this.getForkNodeParams_(),
-              childScriptPath: this.getForkScriptPath_(),
-            }, this.containerContext_),
+            delegate: this.getForkBox(this.mode, this.containerContext_),
           }, this.containerContext_);
         }
         ctx.registry.delegates = workers;

--- a/lib/dao/json_dao_container.es6.js
+++ b/lib/dao/json_dao_container.es6.js
@@ -5,47 +5,31 @@
 
 require('../confluence/api_count_data.es6.js');
 require('../confluence/browser_metric_data.es6.js');
-require('../web_apis/release_interface_relationship.es6.js');
+require('../data_source.es6.js');
+require('../fork.es6.js');
 require('../web_apis/release.es6.js');
+require('../web_apis/release_interface_relationship.es6.js');
 require('../web_apis/web_interface.es6.js');
 require('./dao_container.es6.js');
 require('./http_json_dao.es6.js');
 require('./local_json_dao.es6.js');
 
-foam.ENUM({
-  name: 'JsonDAOContainerMode',
-  package: 'org.chromium.apis.web',
-
-  documentation: `Indicator for what "mode" a JsonDAOContainer should run in.`,
-
-  values: [
-    {
-      name: 'LOCAL',
-      documentation: 'JSON to be loaded from the local filesystem.',
-    },
-    {
-      name: 'HTTP',
-      documentation: 'JSON to be loaded via HTTP GET.'
-    },
-  ],
-});
-
 foam.CLASS({
   name: 'JsonDAOContainer',
   package: 'org.chromium.apis.web',
   extends: 'org.chromium.apis.web.DAOContainer',
+  implements: ['org.chromium.apis.web.ForkBoxFactory'],
 
   requires: [
     'foam.box.BoxRegistry',
     'foam.box.Context',
     'foam.box.SkeletonBox',
-    'foam.box.node.ForkBox',
     'foam.core.StubFactorySingleton',
     'foam.dao.ClientDAO',
     'foam.dao.ReadOnlyDAO',
     'org.chromium.apis.web.ApiCountData',
     'org.chromium.apis.web.BrowserMetricData',
-    'org.chromium.apis.web.JsonDAOContainerMode',
+    'org.chromium.apis.web.DataSource',
     'org.chromium.apis.web.Release',
     'org.chromium.apis.web.ReleaseWebInterfaceJunction',
     'org.chromium.apis.web.SerializableHttpJsonDAO',
@@ -62,8 +46,9 @@ foam.CLASS({
   properties: [
     {
       class: 'Enum',
-      of: 'org.chromium.apis.web.JsonDAOContainerMode',
+      of: 'org.chromium.apis.web.DataSource',
       name: 'mode',
+      required: true,
     },
     {
       class: 'String',
@@ -144,10 +129,11 @@ foam.CLASS({
   methods: [
     function getDAO(cls) {
       this.info(`JsonDaoContainer: Creating DAO for ${cls.id}`);
+      this.validate();
 
       const ctx = this.ctx;
       let serializableDAO;
-      if (this.mode === this.JsonDAOContainerMode.HTTP) {
+      if (this.mode === this.DataSource.HTTP) {
         serializableDAO = this.SerializableHttpJsonDAO.create({
           of: cls,
           url: `${this.basename}/${cls.id}.json`,
@@ -169,11 +155,7 @@ foam.CLASS({
           of: cls,
           // Create fork, and stub its BoxRegistry.
           delegate: this.stubFactory.get(this.BoxRegistry).create({
-            delegate: this.ForkBox.create({
-              critical: true,
-              nodeParams: this.getForkNodeParams_(),
-              childScriptPath: this.getForkScriptPath_(),
-            }, ctx),
+            delegate: this.getForkBox(this.mode, ctx),
 
           // Register skeleton over serializable DAO.
           // ClientDAO's delegate is box returned from register() call.

--- a/lib/data_source.es6.js
+++ b/lib/data_source.es6.js
@@ -1,0 +1,22 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+foam.ENUM({
+  name: 'DataSource',
+  package: 'org.chromium.apis.web',
+
+  documentation: `Indicator for what "mode" of data sourcing to use.`,
+
+  values: [
+    {
+      name: 'LOCAL',
+      documentation: 'JSON data to be loaded from the local filesystem.',
+    },
+    {
+      name: 'HTTP',
+      documentation: 'JSON data to be loaded via HTTP GET.'
+    },
+  ],
+});

--- a/lib/fork.es6.js
+++ b/lib/fork.es6.js
@@ -1,0 +1,34 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+foam.CLASS({
+  name: 'ForkBoxFactory',
+  package: 'org.chromium.apis.web',
+
+  requires: ['foam.box.node.ForkBox'],
+
+  methods: [
+    function getForkBox(mode, ctx) {
+      return this.ForkBox.create({
+        critical: true,
+        nodeParams:  this.getForkNodeParams_(),
+        childScriptPath: this.getForkScriptPath_(),
+        childScriptParams: [mode.toString()],
+      }, ctx);
+    },
+    function getForkNodeParams_() { return ['--max_old_space_size=4096']; },
+    function getForkScriptPath_() {
+      return require('path').resolve(`${__dirname}/../../main/forkScript.js`);
+    },
+  ]
+});
+
+foam.CLASS({
+  name: 'ForkBoxFactorySingleton',
+  package: 'org.chromium.apis.web',
+  extends: 'org.chromium.apis.web.ForkBoxFactory',
+
+  axioms: [foam.pattern.Singleton.create()],
+});

--- a/lib/web_catalog/object_graph_importer.es6.js
+++ b/lib/web_catalog/object_graph_importer.es6.js
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 'use strict';
 
+require('../data_source.es6.js');
+require('../fork.es6.js');
 require('../web_apis/api_importer.es6.js');
 require('../web_apis/release.es6.js');
 require('../web_apis/release_interface_relationship.es6.js');
@@ -17,6 +19,7 @@ const path = require('path');
 foam.CLASS({
   name: 'ObjectGraphImporter',
   package: 'org.chromium.apis.web',
+  implements: ['org.chromium.apis.web.ForkBoxFactory'],
 
   documentation: `Object graph importer handles importing releases' APIs from
       object graph files.`,
@@ -27,7 +30,6 @@ foam.CLASS({
     'foam.box.Context',
     'foam.box.RegisterSelfMessage',
     'foam.box.SkeletonBox',
-    'foam.box.node.ForkBox',
     'foam.core.StubFactorySingleton',
     'org.chromium.apis.web.ApiExtractor',
     'org.chromium.apis.web.ApiExtractorService',
@@ -39,6 +41,12 @@ foam.CLASS({
   imports: ['info'],
 
   properties: [
+    {
+      class: 'Enum',
+      of: 'org.chromium.apis.web.DataSource',
+      name: 'mode',
+      required: true,
+    },
     {
       name: 'apiImporter',
       documentation: 'Imports interface catalog to DAO.',
@@ -93,6 +101,8 @@ foam.CLASS({
       of: 'foam.box.Context',
       name: 'apiContext_',
       factory: function() {
+        this.validate();
+
         let ctx = this.Context.create({
           unsafe: false,
           classWhitelist: require('../../data/class_whitelist.json'),
@@ -104,11 +114,7 @@ foam.CLASS({
         for (let i = 0; i < numWorkers; i++) {
           // Stub BoxRegistry interface over box addressed to new fork.
           workers[i] = this.stubFactory.get(this.BoxRegistry).create({
-            delegate: this.ForkBox.create({
-              critical: true,
-              nodeParams: this.getForkNodeParams_(),
-              childScriptPath: this.getForkScriptPath_(),
-            }, this.containerContext_),
+            delegate: this.getForkBox(this.mode, this.containerContext_),
           }, this.containerContext_);
         }
         ctx.registry.delegates = workers;

--- a/main/forkScript.js
+++ b/main/forkScript.js
@@ -10,34 +10,71 @@
 
 const fs = require('fs');
 const path = require('path');
+const process = require('process');
 
 global.FOAM_FLAGS = {gcloud: true};
 require(path.resolve(`${__dirname}/../node_modules/foam2/src/foam.js`));
 
 require('../lib/compat.es6.js');
-require('../lib/confluence/lone_removal.es6.js');
 require('../lib/confluence/api_count.es6.js');
 require('../lib/confluence/browser_specific.es6.js');
 require('../lib/confluence/lone_omission.es6.js');
+require('../lib/confluence/lone_removal.es6.js');
 require('../lib/confluence/metric_computer_service.es6.js');
 require('../lib/dao/dao_container.es6.js');
 require('../lib/dao/http_json_dao.es6.js');
 require('../lib/dao/local_json_dao.es6.js');
+require('../lib/data_source.es6.js');
 require('../lib/parse/expressions.es6.js');
 require('../lib/web_apis/api_compat_data.es6.js');
-require('../lib/web_apis/release_interface_relationship.es6.js');
 require('../lib/web_apis/release.es6.js');
+require('../lib/web_apis/release_interface_relationship.es6.js');
 require('../lib/web_apis/web_interface.es6.js');
 require('../lib/web_catalog/api_extractor_service.es6.js');
 const pkg = org.chromium.apis.web;
+
+const USAGE = `USAGE:
+
+    node /path/to/forkScript.js DataSource
+
+        DataSource = [ ${pkg.DataSource.VALUES
+            .map(value => value.name).join(' | ')} ]`;
 
 const logger = foam.log.ConsoleLogger.create();
 
 const compatClassFile = pkg.DAOContainer.COMPAT_MODEL_FILE_NAME;
 
+function panic(msg) {
+  console.error(msg);
+  console.error(USAGE);
+  process.exit(1);
+}
+
+function getMode(str) {
+  const mode = pkg.DataSource.VALUES.find(function(value) {
+    return value.name === str;
+  });
+
+  if (mode) return mode;
+
+  const modeNames = Enum.VALUES.map(function(value) {
+    return value.name;
+  });
+  panic(`Invalid ${pkg.DataSource.name} (not one of "${modeNames
+    .join('", "')}")`);
+
+  return null;
+}
+
+// process.argv = /path/to/node /path/to/script <args>
+const args = process.argv.slice(2);
+if (args.length !== 1) panic('Expected exactly one script argument');
+const mode = getMode(args[0]);
+
 // TODO(markdittmer): This should be local or remote based on param passed to
 // parent. It should be forwarded to forkScript invocation.
-const compatClassURL =
+const compatClassURL = mode === pkg.DataSource.LOCAL ?
+    `file://${__dirname}/../data/json/${compatClassFile}` :
     `${require('../data/http_json_dao_base_url.json')}/${compatClassFile}`;
 org.chromium.apis.web.ClassGenerator.create({
   classURL: compatClassURL,

--- a/main/json_to_metrics.es6.js
+++ b/main/json_to_metrics.es6.js
@@ -14,6 +14,7 @@ require('../lib/confluence/browser_metric_data.es6.js');
 require('../lib/confluence/metric_computer_runner.es6.js');
 require('../lib/dao/dao_container.es6.js');
 require('../lib/dao/local_json_dao.es6.js');
+require('../lib/data_source.es6.js');
 require('../lib/web_apis/api_compat_data.es6.js');
 require('../lib/web_apis/release.es6.js');
 require('../lib/web_apis/release_interface_relationship.es6.js');
@@ -51,7 +52,9 @@ pkg.ClassGenerator.create({
     of: pkg.ApiCountData,
   }, container);
 
-  const runner = pkg.MetricComputerRunner.create(null, container);
+  const runner = pkg.MetricComputerRunner.create({
+    mode: pkg.DataSource.LOCAL,
+  }, container);
 
   //
   // Compute data, then store it in data/json/{class}.json

--- a/main/og_to_json.es6.js
+++ b/main/og_to_json.es6.js
@@ -19,11 +19,12 @@ const path = require('path');
 global.FOAM_FLAGS = {gcloud: true};
 require('foam2');
 
+require('../lib/dao/dao_container.es6.js');
+require('../lib/data_source.es6.js');
 require('../lib/web_apis/release.es6.js');
 require('../lib/web_apis/release_interface_relationship.es6.js');
 require('../lib/web_apis/web_interface.es6.js');
 require('../lib/web_catalog/object_graph_importer.es6.js');
-require('../lib/dao/dao_container.es6.js');
 const pkg = org.chromium.apis.web;
 
 //
@@ -42,6 +43,7 @@ container.releaseWebInterfaceJunctionDAO = foam.dao.MDAO.create({
 }, container);
 
 const importer = pkg.ObjectGraphImporter.create({
+  mode: pkg.DataSource.LOCAL,
   objectGraphPath: path.resolve(`${__dirname}/../data/object-graph`),
 }, container);
 

--- a/main/relational_to_compat.es6.js
+++ b/main/relational_to_compat.es6.js
@@ -17,6 +17,7 @@ require('../lib/action.es6.js');
 require('../lib/dao/http_json_dao.es6.js');
 require('../lib/dao/json_dao_container.es6.js');
 require('../lib/dao/local_json_dao.es6.js');
+require('../lib/data_source.es6.js');
 require('../lib/web_apis/api_compat_data.es6.js');
 require('../lib/web_apis/relational_to_compat.es6.js');
 require('../lib/web_apis/release.es6.js');
@@ -49,8 +50,8 @@ if (dataUrl.protocol !== 'file:' && dataUrl.protocol !== 'https:') {
 }
 
 let container = pkg.JsonDAOContainer.create({
-  mode: dataUrl.protocol === 'file:' ? pkg.JsonDAOContainerMode.LOCAL :
-      pkg.JsonDAOContainerMode.HTTP,
+  mode: dataUrl.protocol === 'file:' ? pkg.DataSource.LOCAL :
+      pkg.DataSource.HTTP,
   basename: dataUrl.protocol === 'file:' ? dataUrl.pathname :
       url.format(dataUrl),
 }, logger);

--- a/main/relational_to_grid.es6.js
+++ b/main/relational_to_grid.es6.js
@@ -14,6 +14,7 @@ require('../lib/dao/grid_dao.es6.js');
 require('../lib/dao/http_json_dao.es6.js');
 require('../lib/dao/json_dao_container.es6.js');
 require('../lib/dao/local_json_dao.es6.js');
+require('../lib/data_source.es6.js');
 require('../lib/web_apis/release.es6.js');
 require('../lib/web_apis/release_interface_relationship.es6.js');
 require('../lib/web_apis/web_interface.es6.js');
@@ -43,8 +44,8 @@ if (dataUrl.protocol !== 'file:' && dataUrl.protocol !== 'https:') {
 }
 
 let container = pkg.JsonDAOContainer.create({
-  mode: dataUrl.protocol === 'file:' ? pkg.JsonDAOContainerMode.LOCAL :
-      pkg.JsonDAOContainerMode.HTTP,
+  mode: dataUrl.protocol === 'file:' ? pkg.DataSource.LOCAL :
+      pkg.DataSource.HTTP,
   basename: dataUrl.protocol === 'file:' ? dataUrl.pathname : url.format(dataUrl),
 }, logger);
 

--- a/main/serve.js
+++ b/main/serve.js
@@ -17,25 +17,26 @@ global.FOAM_FLAGS = {gcloud: true};
 require('foam2');
 
 require('../lib/compat.es6.js');
-require('../lib/confluence/lone_removal.es6.js');
 require('../lib/confluence/api_count.es6.js');
 require('../lib/confluence/browser_specific.es6.js');
 require('../lib/confluence/lone_omission.es6.js');
+require('../lib/confluence/lone_removal.es6.js');
 require('../lib/dao/json_dao_container.es6.js');
+require('../lib/data_source.es6.js');
 require('../lib/parse/expressions.es6.js');
 require('../lib/server/server.es6.js');
 require('../lib/web_apis/api_compat_data.es6.js');
-require('../lib/web_apis/release_interface_relationship.es6.js');
 require('../lib/web_apis/release.es6.js');
+require('../lib/web_apis/release_interface_relationship.es6.js');
 require('../lib/web_apis/web_interface.es6.js');
 const pkg = org.chromium.apis.web;
 
 const USAGE = `USAGE:
 
-    node /path/to/serve.js JsonDAOContainerMode ServerMode
+    node /path/to/serve.js DataSource ServerMode
 
-        JsonDAOContainerMode = [ ${pkg.JsonDAOContainerMode.VALUES.map(
-                                       value => value.name).join(' | ')} ]
+        DataSource = [ ${pkg.DataSource.VALUES
+            .map(value => value.name).join(' | ')} ]
 
         ServerMode = [ ${pkg.ServerMode.VALUES.map(
                              value => value.name).join(' | ')} ]`;
@@ -58,9 +59,9 @@ foam.CLASS({
 });
 
 function getModeString(Enum, str) {
-  const mode = Enum.VALUES.filter(function(value) {
+  const mode = Enum.VALUES.find(function(value) {
     return value.name === str;
-  })[0];
+  });
 
   if (mode) return mode;
 
@@ -74,13 +75,13 @@ function getModeString(Enum, str) {
   return null;
 }
 
-const containerMode = getModeString(pkg.JsonDAOContainerMode, process.argv[2]);
+const containerMode = getModeString(pkg.DataSource, process.argv[2]);
 const serverMode = getModeString(pkg.ServerMode, process.argv[3]);
 
 
 const logger = foam.log.ConsoleLogger.create();
 
-const basename = containerMode === pkg.JsonDAOContainerMode.LOCAL ?
+const basename = containerMode === pkg.DataSource.LOCAL ?
       `file://${__dirname}/../data/json` :
       require('../data/http_json_dao_base_url.json');
 

--- a/test/node/dataQuality-integration.es6.js
+++ b/test/node/dataQuality-integration.es6.js
@@ -31,13 +31,14 @@ xdescribe('data quality', function() {
     require('../../lib/confluence/api_count_data.es6.js');
     require('../../lib/confluence/browser_metric_data.es6.js');
     require('../../lib/dao/json_dao_container.es6.js');
+    require('../../lib/data_source.es6.js');
     require('../../lib/web_apis/release.es6.js');
     require('../../lib/web_apis/release_interface_relationship.es6.js');
     require('../../lib/web_apis/web_interface.es6.js');
     const pkg = org.chromium.apis.web;
 
     ctx = pkg.JsonDAOContainer.create({
-      mode: pkg.JsonDAOContainerMode.HTTP,
+      mode: pkg.DataSource.HTTP,
       basename: 'https://storage.googleapis.com/web-api-confluence-data-cache/latest/json',
     }).ctx;
 


### PR DESCRIPTION
This enables passing mode to forks to ensure that LOCAL vs HTTP code+data loading is consistent between processes.

The change also consolidates logic that controls how forks are initialized via ForkBox configuration.