### PR TITLE
Change terse version numbers to include 1-2 components

### DIFF
--- a/lib/parse/parser_interpreter.es6.js
+++ b/lib/parse/parser_interpreter.es6.js
@@ -176,18 +176,15 @@ foam.LIB({
         foam.assert(parts.length === 4, `Unexpected release ID format: ${id}`);
 
         const browserVersion = parts[1];
-        const browserVersionLastDot = browserVersion.lastIndexOf('.');
-        foam.assert(browserVersionLastDot !== -1,
-                    `Unexpected browser version ${browserVersion}`);
+        const terseBrowserVersion = browserVersion.split('.').slice(0, 2)
+            .join('.');
         const osVersion = parts[3];
-        const osVersionLastDot = osVersion.lastIndexOf('.');
-        foam.assert(osVersionLastDot !== -1,
-                    `Unexpected os version ${osVersion}`);
+        const terseOSVersion = osVersion.split('.').slice(0, 2).join('.');
 
         parts[0] = parts[0].substr(0, 3);
-        parts[1] = browserVersion.substr(0, browserVersionLastDot);
+        parts[1] = terseBrowserVersion;
         parts[2] = parts[2].substr(0, 3);
-        parts[3] = osVersion.substr(0, osVersionLastDot);
+        parts[3] = terseOSVersion;
 
         return parts.join('');
       },

--- a/test/any/parse/parser_interpreter-test.es6.js
+++ b/test/any/parse/parser_interpreter-test.es6.js
@@ -229,9 +229,9 @@ describe('QueryParser', () => {
     const terseIDs = releaseIDs.map(org.chromium.parse.util.getTerseReleaseId);
 
     expect(terseIDs).toEqual([
-      'alp1new3.1',
-      'bet54.1old15',
-      'alp2.2old12',
+      'alp1.0new3.1',
+      'bet54.1old15.0',
+      'alp2.2old12.1',
     ]);
   });
 });


### PR DESCRIPTION
Links from Safari API count graph to associated catalog views are broken because, for example, sometimes '11' is used as a version number where '11.0' or '11.1' is needed. This change ensures that generated queries that contain so-called 'terse version numbers' include at least 2 components when available.