### PR TITLE
Resurrect GridDAO

### DIFF
--- a/lib/dao/grid_dao.es6.js
+++ b/lib/dao/grid_dao.es6.js
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+require('../parse/expressions.es6.js');
+
 foam.CLASS({
   package: 'org.chromium.apis.web',
   name: 'GridRow',
@@ -62,23 +64,6 @@ foam.CLASS({
 
 foam.CLASS({
   package: 'org.chromium.mlang',
-  name: 'Truthy',
-  extends: 'foam.mlang.ExprProperty',
-
-  axioms: [foam.pattern.Singleton.create()],
-
-  properties: [
-    {
-      name: 'f',
-      value: function(v) { return !!v; },
-    },
-  ],
-
-  methods: [function toString() { return 'TRUTHY'; }],
-});
-
-foam.CLASS({
-  package: 'org.chromium.mlang',
   name: 'ArrayExtract',
   extends: 'foam.mlang.predicate.Nary',
 
@@ -100,33 +85,6 @@ foam.CLASS({
         extracted[i] = array[offsets[i]];
       }
       return extracted;
-    },
-  ],
-});
-
-foam.CLASS({
-  package: 'org.chromium.mlang',
-  name: 'ArrayCount',
-  extends: 'foam.mlang.predicate.Binary',
-
-  documentation: `Predicate that counts number of array elements from "arg1"
-      returns truthy when applied to "arg2".
-
-      E.g., myGridDAO.where(EQ(ARRAY_COUNT(
-                myGridDAO.extractCols(
-                    myGridDAO.cols[10],
-                    myGridDAO.cols[7],
-                    myGridDAO.cols[45]),
-                TRUTHY()), 1))`,
-
-  methods: [
-    function f(o) {
-      const array = this.arg1.f(o);
-      let count = 0;
-      for (const element of array) {
-        if (this.arg2.f(element)) count++;
-      }
-      return count;
     },
   ],
 });

--- a/lib/dao/grid_dao.es6.js
+++ b/lib/dao/grid_dao.es6.js
@@ -1,0 +1,240 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+foam.CLASS({
+  package: 'org.chromium.apis.web',
+  name: 'GridRow',
+
+  properties: [
+    {
+      name: 'id',
+    },
+    {
+      class: 'Array',
+      documentation: 'Data items parallel to GridDAO.cols.',
+      name: 'data',
+    },
+  ],
+});
+
+foam.CLASS({
+  package: 'org.chromium.mlang',
+  name: 'Projection',
+  extends: 'foam.mlang.ExprProperty',
+
+  documentation: `Projection over particular data columns that retains GridRow
+      state. I.e., f() implementation is GridRow => GridRow, but modifies
+      GridRow.data. Primarliy used to implement GridDAO.projectCols().
+
+      E.g., myGridDAO.select(MAP(myGridDAO.projectCols(
+                myGridDAO.cols[10],
+                myGridDAO.cols[7],
+                myGridDAO.cols[45])))`,
+
+  requires: ['org.chromium.apis.web.GridRow'],
+
+  properties: [
+    {
+      class: 'Array',
+      of: 'Int',
+      name: 'cols',
+    },
+    {
+      name: 'f',
+      value: function f(gridRow) {
+        let row = this.GridRow.create({
+          id: gridRow.id && gridRow.id.clone ? gridRow.id.clone(this) :
+              gridRow.id,
+        });
+        let allData = gridRow.data;
+        const cols = this.cols;
+        let data = new Array(cols.length);
+        for (let i = 0; i < cols.length; i++) {
+          data[i] = allData[cols[i]];
+        }
+        row.data = data;
+        return row;
+      },
+    },
+  ],
+});
+
+foam.CLASS({
+  package: 'org.chromium.mlang',
+  name: 'Truthy',
+  extends: 'foam.mlang.ExprProperty',
+
+  axioms: [foam.pattern.Singleton.create()],
+
+  properties: [
+    {
+      name: 'f',
+      value: function(v) { return !!v; },
+    },
+  ],
+
+  methods: [function toString() { return 'TRUTHY'; }],
+});
+
+foam.CLASS({
+  package: 'org.chromium.mlang',
+  name: 'ArrayExtract',
+  extends: 'foam.mlang.predicate.Nary',
+
+  documentation: `Predicate that extract elements of an array. Similar to
+      Projection, but f() implementation is
+      GridRow => extractThisDotArgs(GridRow.data). Primarily used to implement
+      GridDAO.extractCols().
+
+      E.g., myGridDAO.where(EQ(myGridDAO.extractCols(
+                myGridDAO.cols[10],
+                myGridDAO.cols[7],
+                myGridDAO.cols[45]), [true, false, true]))`,
+
+  methods: [
+    function f(array) {
+      const offsets = this.args;
+      let extracted = new Array(offsets.length);
+      for (let i = 0; i < offsets.length; i++) {
+        extracted[i] = array[offsets[i]];
+      }
+      return extracted;
+    },
+  ],
+});
+
+foam.CLASS({
+  package: 'org.chromium.mlang',
+  name: 'ArrayCount',
+  extends: 'foam.mlang.predicate.Binary',
+
+  documentation: `Predicate that counts number of array elements from "arg1"
+      returns truthy when applied to "arg2".
+
+      E.g., myGridDAO.where(EQ(ARRAY_COUNT(
+                myGridDAO.extractCols(
+                    myGridDAO.cols[10],
+                    myGridDAO.cols[7],
+                    myGridDAO.cols[45]),
+                TRUTHY()), 1))`,
+
+  methods: [
+    function f(o) {
+      const array = this.arg1.f(o);
+      let count = 0;
+      for (const element of array) {
+        if (this.arg2.f(element)) count++;
+      }
+      return count;
+    },
+  ],
+});
+
+foam.CLASS({
+  package: 'org.chromium.mlang',
+  name: 'GridExpressions',
+  refines: 'foam.mlang.Expressions',
+
+  requires: [
+    'org.chromium.mlang.ArrayCount',
+    'org.chromium.mlang.ArrayExtract',
+    'org.chromium.mlang.Truthy',
+  ],
+
+  methods: [
+    function TRUTHY() { return this.Truthy.create(); },
+    function ARRAY_EXTRACT() {
+      return this.ArrayExtract.create({
+        args: Array.from(arguments),
+      });
+    },
+    function ARRAY_COUNT(arrayMLang, predicatMLang) {
+      return this.ArrayCount.create({arg1: arrayMLang, arg2: predicatMLang});
+    },
+  ],
+});
+
+foam.CLASS({
+  package: 'org.chromium.apis.web',
+  name: 'GridDAO',
+  extends: 'foam.dao.ProxyDAO',
+  implements: ['org.chromium.mlang.GridExpressions'],
+
+  documentation: 'DAO of GridRows that stores GridRow.data metadata.',
+
+  requires: [
+    'foam.dao.MDAO',
+    'org.chromium.apis.web.GridRow',
+    'org.chromium.mlang.Projection',
+  ],
+  imports: ['warn'],
+
+  properties: [
+    {
+      name: 'of',
+      value: 'org.chromium.apis.web.GridRow',
+    },
+    {
+      name: 'delegate',
+      factory: function() {
+        return this.MDAO.create({of: this.of});
+      },
+    },
+    {
+      class: 'Array',
+      documentation: 'Column metadata items parallel to GridRow.data.',
+      name: 'cols',
+      final: true,
+      required: true,
+    },
+  ],
+
+  methods: [
+    {
+      name: 'colIndexOf',
+      documentation: `Return the array index (in "cols") of "col". If "col" does
+          not appear in "cols", then return -1. Comparisons performed using
+          "FOAM equality": foam.util.compare().`,
+      code: function(col) {
+        const cols = this.cols;
+        for (let i = 0; i < cols.length; i++) {
+          if (foam.util.equals(cols[i], col)) return i;
+        }
+        return -1;
+      },
+    },
+    {
+      name: 'projectCols',
+      documentation: `Return a foam.mlang.ExprProperty that transforms a GridRow
+          into a modified GridRow with data set to the list of columns described
+          by arguments. Drop/ignore arguments that do not match any member of
+          "cols".`,
+      code: function() {
+        const cols = this.getColIdxs_(Array.from(arguments));
+        return this.Projection.create({cols});
+      },
+    },
+    {
+      name: 'extractCols',
+      documentation: `Return a predicate that extracts from a GridRow the
+          columns in its "data" described by arguments. Drop/ignore arguments
+          that do not match any member of "cols".`,
+      code: function() {
+        const cols = this.getColIdxs_(Array.from(arguments));
+        return this.DOT(this.GridRow.DATA, this.ArrayExtract.create({
+          args: cols,
+        }));
+      },
+    },
+    function getColIdxs_(cols) {
+      const idxs = cols.map(this.colIndexOf.bind(this));
+      for (let i = 0; i < idxs.length; i++) {
+        if (idxs[i] === -1) {
+          this.warn('Ignoring unknown GridDAO column:', cols[i]);
+        }
+      }
+      return idxs.filter(idx => idx !== -1);
+    },
+  ],
+});

--- a/test/any/dao/grid_dao-test.es6.js
+++ b/test/any/dao/grid_dao-test.es6.js
@@ -1,0 +1,227 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+'use strict';
+
+
+describe('GridDAO', () => {
+  it('should use FOAM object equality for colIndexOf', () => {
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'RGBA',
+
+      properties: [
+        {
+          class: 'Float',
+          name: 'r',
+        },
+        {
+          class: 'Float',
+          name: 'g',
+        },
+        {
+          class: 'Float',
+          name: 'b',
+        },
+        {
+          class: 'Float',
+          name: 'a',
+          value: 1.0,
+        },
+      ],
+    });
+
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'Color',
+
+      properties: [
+        {
+          class: 'String',
+          name: 'name',
+        },
+        {
+          class: 'FObjectProperty',
+          of: 'org.chromium.apis.web.test.RGBA',
+          name: 'rgba',
+        },
+      ],
+    });
+
+    const RGBA = org.chromium.apis.web.test.RGBA;
+    const Color = org.chromium.apis.web.test.Color;
+
+    const dao = org.chromium.apis.web.GridDAO.create({
+      cols: [
+        Color.create({name: 'red', rgba: RGBA.create({r: 1.0})}),
+        Color.create({name: 'green', rgba: RGBA.create({g: 1.0})}),
+        Color.create({name: 'blue', rgba: RGBA.create({b: 1.0})}),
+      ],
+    });
+
+    expect(dao.colIndexOf(Color.create())).toBe(-1);
+    expect(dao.colIndexOf(null)).toBe(-1);
+    expect(dao.colIndexOf(undefined)).toBe(-1);
+    expect(dao.colIndexOf(foam.core.FObject.create())).toBe(-1);
+    expect(dao.colIndexOf(-1)).toBe(-1);
+    expect(dao.colIndexOf(true)).toBe(-1);
+    expect(dao.colIndexOf(false)).toBe(-1);
+    expect(dao.colIndexOf(Infinity)).toBe(-1);
+
+    expect(dao.colIndexOf(Color.create({
+      name: 'red',
+      rgba: RGBA.create({r: 1.0}),
+    }))).toBe(0);
+    expect(dao.colIndexOf(Color.create({
+      name: 'green',
+      rgba: RGBA.create({g: 1.0}),
+    }))).toBe(1);
+    expect(dao.colIndexOf(Color.create({
+      name: 'blue',
+      rgba: RGBA.create({b: 1.0}),
+    }))).toBe(2);
+  });
+
+  it('should project appropriately on proper use of projectCols()', done => {
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'Col',
+
+      properties: [
+        {
+          class: 'String',
+          name: 'id',
+        },
+      ],
+    });
+    const Col = org.chromium.apis.web.test.Col;
+    const dao = org.chromium.apis.web.GridDAO.create({
+      cols: [
+        Col.create({id: 'A'}),
+        Col.create({id: 'B'}),
+        Col.create({id: 'C'}),
+        Col.create({id: 'D'}),
+      ],
+    });
+    const E = foam.mlang.ExpressionsSingleton.create();
+    const GridRow = org.chromium.apis.web.GridRow;
+    Promise.all([
+      dao.put(GridRow.create({id: 0, data: [1, 0, 0, 0]})),
+      dao.put(GridRow.create({id: 1, data: [0, 1, 0, 0]})),
+      dao.put(GridRow.create({id: 2, data: [0, 0, 1, 0]})),
+      dao.put(GridRow.create({id: 3, data: [0, 0, 0, 1]})),
+    ]).then(() => {
+      return dao.orderBy(GridRow.ID).select(E.MAP(
+          dao.projectCols(dao.cols[3], dao.cols[2], dao.cols[1], dao.cols[0])));
+    }).then(mapSink => {
+      const array = mapSink.delegate.array;
+      expect(array[0].id).toBe(0);
+      expect(array[1].id).toBe(1);
+      expect(array[2].id).toBe(2);
+      expect(array[3].id).toBe(3);
+      expect(array[0].data).toEqual([0, 0, 0, 1]);
+      expect(array[1].data).toEqual([0, 0, 1, 0]);
+      expect(array[2].data).toEqual([0, 1, 0, 0]);
+      expect(array[3].data).toEqual([1, 0, 0, 0]);
+      done();
+    }).catch(done.fail);
+  });
+
+  it('should project appropriately over a subset of cols using projectCols()', done => {
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'Col',
+
+      properties: [
+        {
+          class: 'String',
+          name: 'id',
+        },
+      ],
+    });
+    const Col = org.chromium.apis.web.test.Col;
+    const dao = org.chromium.apis.web.GridDAO.create({
+      cols: [
+        Col.create({id: 'A'}),
+        Col.create({id: 'B'}),
+        Col.create({id: 'C'}),
+        Col.create({id: 'D'}),
+      ],
+    });
+    const E = foam.mlang.ExpressionsSingleton.create();
+    const GridRow = org.chromium.apis.web.GridRow;
+    Promise.all([
+      dao.put(GridRow.create({id: 0, data: [1, 0, 0, 0]})),
+      dao.put(GridRow.create({id: 1, data: [0, 1, 0, 0]})),
+      dao.put(GridRow.create({id: 2, data: [0, 0, 1, 0]})),
+      dao.put(GridRow.create({id: 3, data: [0, 0, 0, 1]})),
+    ]).then(() => {
+      return dao.orderBy(GridRow.ID).select(E.MAP(
+          dao.projectCols(dao.cols[3], dao.cols[1])));
+    }).then(mapSink => {
+      const array = mapSink.delegate.array;
+      expect(array[0].id).toBe(0);
+      expect(array[1].id).toBe(1);
+      expect(array[2].id).toBe(2);
+      expect(array[3].id).toBe(3);
+      expect(array[0].data).toEqual([0, 0]);
+      expect(array[1].data).toEqual([0, 1]);
+      expect(array[2].data).toEqual([0, 0]);
+      expect(array[3].data).toEqual([1, 0]);
+      done();
+    }).catch(done.fail);
+  });
+
+  it('should warn and ignore invalid projection columns', done => {
+    const warn = foam.__context__.warn;
+    let warnCount = 0;
+    const ctx = foam.createSubContext({
+      warn: function() {
+        warnCount++;
+        return warn.apply(this, arguments);
+      },
+    });
+    foam.CLASS({
+      package: 'org.chromium.apis.web.test',
+      name: 'Col',
+
+      properties: [
+        {
+          class: 'String',
+          name: 'id',
+        },
+      ],
+    }, ctx);
+    const Col = org.chromium.apis.web.test.Col;
+    const dao = org.chromium.apis.web.GridDAO.create({
+      cols: [
+        Col.create({id: 'A'}),
+      ],
+    }, ctx);
+    const E = foam.mlang.ExpressionsSingleton.create(null, ctx);
+    const GridRow = org.chromium.apis.web.GridRow;
+    Promise.all([
+      dao.put(GridRow.create({id: 0, data: [0]}, ctx)),
+      dao.put(GridRow.create({id: 1, data: [1]}, ctx)),
+      dao.put(GridRow.create({id: 2, data: [2]}, ctx)),
+      dao.put(GridRow.create({id: 3, data: [3]}, ctx)),
+    ]).then(() => {
+      warnCount = 0;
+      const sink = E.MAP(dao.projectCols(
+          Col.create({id: 'B'}, ctx), dao.cols[0], null, undefined, -1));
+      expect(warnCount).toBe(4);
+      return dao.orderBy(GridRow.ID).select(sink);
+    }).then(mapSink => {
+      const array = mapSink.delegate.array;
+      expect(array[0].id).toBe(0);
+      expect(array[1].id).toBe(1);
+      expect(array[2].id).toBe(2);
+      expect(array[3].id).toBe(3);
+      expect(array[0].data).toEqual([0]);
+      expect(array[1].data).toEqual([1]);
+      expect(array[2].data).toEqual([2]);
+      expect(array[3].data).toEqual([3]);
+      done();
+    }).catch(done.fail);
+  });
+});

--- a/test/any/files-helper.js
+++ b/test/any/files-helper.js
@@ -55,6 +55,7 @@ beforeAll(function() {
   require('../../lib/confluence/set_ops.es6.js');
   require('../../lib/dao/api_service_dao.es6.js');
   require('../../lib/dao/dao_container.es6.js');
+  require('../../lib/dao/grid_dao.es6.js');
   require('../../lib/dao/http_json_dao.es6.js');
   require('../../lib/dao/indexed_dao.es6.js');
   require('../../lib/dao/json_dao_container.es6.js');


### PR DESCRIPTION
It is still required for data collection used by `mdn-confluence`. This PR is a partial revert of #289. Locks in fix for https://github.com/mdittmer/mdn-confluence/issues/27.