### PR TITLE
Update links after GoogleChrome -> GoogleChromeLabs org move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Web API Confluence Dashboard](https://web-confluence.appspot.com) [![Build Status](https://travis-ci.org/GoogleChrome/confluence.svg?branch=master)](https://travis-ci.org/GoogleChrome/confluence)[![Codecov](https://img.shields.io/codecov/c/github/GoogleChrome/confluence.svg)]()
+# [Web API Confluence Dashboard](https://web-confluence.appspot.com) [![Build Status](https://travis-ci.org/GoogleChromeLabs/confluence.svg?branch=master)](https://travis-ci.org/GoogleChromeLabs/confluence)[![Codecov](https://img.shields.io/codecov/c/github/GoogleChromeLabs/confluence.svg)]()
 
 A web service and UI for describing *API confluence metrics*. These metrics are
 intended to capture the how browser vendors

--- a/lib/web_catalog/api_extractor.es6.js
+++ b/lib/web_catalog/api_extractor.es6.js
@@ -228,7 +228,7 @@ foam.CLASS({
           // Copy processors:
           this.CopyToPrototypeProcessor.create({
             fromInterfaceName: 'CSS2Properties',
-            confluenceIssueURL: 'https://github.com/GoogleChrome/confluence/issues/78',
+            confluenceIssueURL: 'https://github.com/GoogleChromeLabs/confluence/issues/78',
             browserBugURL: 'https://bugzilla.mozilla.org/show_bug.cgi?id=1290786',
           }),
           // Keep one copy of global object APIs under "Window".
@@ -241,7 +241,7 @@ foam.CLASS({
           this.RemoveInterfacesProcessor.create({
             otherURLs: [
               // For interface name "a":
-              'https://github.com/GoogleChromeLabs/confluence/issues/299#issuecomment-391119693',
+              'https://github.com/GoogleChromeLabsLabs/confluence/issues/299#issuecomment-391119693',
             ],
             interfaceNames: this.blacklistInterfaces,
           }),
@@ -251,7 +251,7 @@ foam.CLASS({
             confluenceIssueURL: '',
             specURL: 'https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-dashed-attribute',
             otherURLs: [
-              'https://github.com/GoogleChrome/confluence/issues/174',
+              'https://github.com/GoogleChromeLabs/confluence/issues/174',
               'https://github.com/w3c/csswg-drafts/issues/1089',
             ],
           }),

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/GoogleChrome/confluence.git"
+    "url": "git+https://github.com/GoogleChromeLabs/confluence.git"
   },
   "keywords": [
     "javascript",
@@ -26,7 +26,7 @@
     "tools"
   ],
   "author": "Mark Dittmer, Jing Tao",
-  "homepage": "https://github.com/GoogleChrome/confluence#readme",
+  "homepage": "https://github.com/GoogleChromeLabs/confluence#readme",
   "dependencies": {
     "@uirouter/angularjs": "^1.0.18",
     "angular": "^1.7.0",

--- a/static/index.html
+++ b/static/index.html
@@ -88,7 +88,7 @@
     <footer class="page-footer blue darken-2">
       <div class="footer-copyright blue darken-2">
         <a class="grey-text text-lighten-4"
-           href="https://github.com/GoogleChrome/confluence">
+           href="https://github.com/GoogleChromeLabs/confluence">
           Code on GitHub
         </a>
         <div class="">

--- a/static/view/confluence.html
+++ b/static/view/confluence.html
@@ -64,7 +64,7 @@
       <blockquote class="yellow lighten-4 warning">
         This site is a work in progress. If something doesn't seem right
         check out the
-        <a href="https://github.com/GoogleChrome/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22api%20velocity%22">known issues</a>
+        <a href="https://github.com/GoogleChromeLabs/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22api%20velocity%22">known issues</a>
         for this metric.
       </blockquote>
       <p>
@@ -90,7 +90,7 @@
       <blockquote class="yellow lighten-4 warning">
         This site is a work in progress. If something doesn't seem right
         check out the
-        <a href="https://github.com/GoogleChrome/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22failure%20to%20ship%22">known issues</a>
+        <a href="https://github.com/GoogleChromeLabs/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22failure%20to%20ship%22">known issues</a>
         for this metric.
       </blockquote>
       <p>
@@ -124,7 +124,7 @@
       <blockquote class="yellow lighten-4 warning">
         This site is a work in progress. If something doesn't seem right
         check out the
-        <a href="https://github.com/GoogleChrome/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22aggressive%20removal%22">known issues</a>
+        <a href="https://github.com/GoogleChromeLabs/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22aggressive%20removal%22">known issues</a>
         for this metric.
       </blockquote>
       <p>
@@ -160,7 +160,7 @@
       <blockquote class="yellow lighten-4 warning">
         This site is a work in progress. If something doesn't seem right
         check out the
-        <a href="https://github.com/GoogleChrome/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22browser-specific%22">known issues</a>
+        <a href="https://github.com/GoogleChromeLabs/confluence/issues/?utf8=✓&q=is%3Aissue%20is%3Aopen%20label%3Abug%20label%3A%22browser-specific%22">known issues</a>
         for this metric.
       </blockquote>
       <p>

--- a/static/view/home.html
+++ b/static/view/home.html
@@ -41,7 +41,7 @@
     low-level differences in support for APIs and to coordinate work. Data
     reported on the site may not be an accurate reflection of web platform
     implementations. Please refer to
-    <a href="https://github.com/GoogleChrome/confluence/issues">known issues</a>
+    <a href="https://github.com/GoogleChromeLabs/confluence/issues">known issues</a>
     on GitHub for more information.
   </blockquote>
   <!-- <div id="intro" class="card horizontal">
@@ -107,7 +107,7 @@
         </p>
         <p>
 	  A precise definition of the metrics can be found
-	  <a href="https://github.com/GoogleChrome/confluence#the-metrics">here</a>.
+	  <a href="https://github.com/GoogleChromeLabs/confluence#the-metrics">here</a>.
         </p>
       </div>
       <div class="card-action">


### PR DESCRIPTION
This is mainly to fix the badges at the top of README.md.