### PR TITLE
Fix one failing unit test

### DIFF
--- a/lib/web_catalog/api_extractor_service.es6.js
+++ b/lib/web_catalog/api_extractor_service.es6.js
@@ -94,12 +94,14 @@ foam.CLASS({
       let ret = {browser: {}, platform: {}};
 
       // Drop slice(0, -5): ".json".
-      foam.assert(filename.endsWith('.json'),
-                  'Object graph JSON file must end with ".json"');
+      if (!filename.endsWith('.json')) {
+        throw new Error('Object graph JSON file must end with ".json"');
+      }
       const releaseInfo = filename.slice(0, -5).split('_');
-      foam.assert(releaseInfo.length === 5,
-                  `Object graph JSON file name expected to be of the form:
-                      window_[browser-name]_[browser-version]_[platform-name][platform-version].json`);
+      if (releaseInfo.length !== 5) {
+        throw new Error('Object graph JSON file name expected to be of the form ' +
+                        'window_[browser-name]_[browser-version]_[platform-name][platform-version].json');
+      }
       ret.browser.name = releaseInfo[1];
       ret.browser.version = releaseInfo[2];
       ret.platform.name = releaseInfo[3];


### PR DESCRIPTION
At one point `foam.assert` must have thrown an exception, but is now
just a wrapper for `console.assert` and does not throw. Replace this
with conditional `throw new Error` which is already used elsewhere.

Part of https://github.com/GoogleChromeLabs/confluence/issues/338.

