### PR TITLE
Rewrite stray jQuery dependency used for Materialize Tabs

### DIFF
--- a/lib/controller/api_confluence.es6.js
+++ b/lib/controller/api_confluence.es6.js
@@ -17,8 +17,8 @@ angular.module('confluence')
   .controller('confluenceController', ['$scope', 'api', function($scope, api) {
     api.urlState.clearBindings();
 
-    // Activate tabs.
-    $('ul.tabs').tabs();
+    // https://materializecss.com/tabs.html#initialization
+    M.Tabs.init(document.querySelector('ul.tabs'));
     $scope.showTab = 0;
     $scope.apiCountMetrics = {};
     $scope.browserMetric = null;


### PR DESCRIPTION
Broken by https://github.com/GoogleChromeLabs/confluence/pull/346 and
noticed when trying to deploy from scratch. In previous efforts to
verify the webpack was probably not updated.

The UI component used here is https://materializecss.com/tabs.html