### PR TITLE
Allow deploying without symlinking node_modules/foam2

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -25,35 +25,15 @@ CONFLUENCE_CLEAN_OUTPUT=$(git clean --dry-run)
 CONFLUENCE_VERSION=$(git rev-parse HEAD)
 popd > /dev/null
 
-pushd "${WD}/../node_modules/foam2" > /dev/null
-FOAM2_DIFF_OUTPUT=$(git diff --stat)
-FOAM2_CLEAN_OUTPUT=$(git clean --dry-run)
-FOAM2_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-FOAM2_VERSION=$(git rev-parse HEAD)
-popd > /dev/null
-
 if [[ "${CONFLUENCE_VERSION}" = "" ]]; then
   error "Main source is not under version control. Is this not a git clone?"
-  exit 1
-fi
-if [[ "${FOAM2_VERSION}" = "" || "${CONFLUENCE_VERSION}" = "${FOAM2_VERSION}" ]]; then
-  error "FOAM2 is not under version control. Did you forget to symlink /path/to/foam2 -> node_modules/foam2?"
   exit 1
 fi
 if [[ "${CONFLUENCE_DIFF_OUTPUT}" != "" || "${CONFLUENCE_CLEAN_OUTPUT}" != "" ]]; then
   error "Your working tree is not clean"
   exit 1
 fi
-if [[ "${FOAM2_DIFF_OUTPUT}" != "" || "${FOAM2_CLEAN_OUTPUT}" != "" ]]; then
-  error "FOAM2 working tree is not clean"
-  exit 1
-fi
-# TODO(markdittmer): Keep package.json branch name and this branch name in sync.
-if [[ "${FOAM2_BRANCH}" != "confluence" ]]; then
-  error "FOAM2 checked out to wrong branch: ${FOAM2_BRANCH}"
-  exit 1
-fi
-win "Preparing build for Confluence@${CONFLUENCE_VERSION}, FOAM2@${FOAM2_VERSION}"
+win "Preparing build for Confluence@${CONFLUENCE_VERSION}"
 
 if ! webpack --config "${WD}/../config/webpack.prod.js"; then
   error "webpack failed"
@@ -62,7 +42,7 @@ fi
 win "Deploying"
 
 if gcloud config set project web-confluence && \
-    gcloud app deploy --no-promote --version="confluence-${CONFLUENCE_VERSION:0:7}--foam2-${FOAM2_VERSION:0:7}"; then
+    gcloud app deploy --no-promote --version="confluence-${CONFLUENCE_VERSION:0:7}"; then
   win "App deployed! Exiting."
 else
   error "App deployment failed"


### PR DESCRIPTION
The exact version of foam2 deployed is saved in package-lock.json and
not commiting any change results in "Your working tree is not clean",
so since we don't need to change the version of foam2 used without
also updating the confluence repo, deploy can be simplified.

This is the only (apparent) remaining reason that node_modules/foam2
needs to be symlinked to a full foam2 checkout.