### PR TITLE
Encode data: URL correctly in download handler

### DIFF
--- a/lib/u2/DAOControllerView.es6.js
+++ b/lib/u2/DAOControllerView.es6.js
@@ -308,8 +308,7 @@ foam.CLASS({
             str += '\n';
           }
 
-          const csv = `data:text/csv;charset=utf-8,${str}`;
-          const href = encodeURI(csv);
+          const href = `data:text/csv;charset=utf-8,${encodeURIComponent(str)}`;
           const link = document.createElement('a');
           link.style.display = 'none';
           link.setAttribute('href', href);


### PR DESCRIPTION
Fixes https://github.com/GoogleChromeLabs/confluence/issues/328.