### PR TITLE
Revert back to `runtime: nodejs` for app.yaml, meaning Node.JS 10

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-runtime: nodejs8
+runtime: nodejs
 env: flex
 resources:
   cpu: 4


### PR DESCRIPTION
Changed to nodejs8 in https://github.com/GoogleChromeLabs/confluence/pull/360,
but it doesn't actually work. The version of Node.JS used in AppEngine flex is
determined by the Docker base image, and is currently 10.15.3:
https://github.com/GoogleCloudPlatform/nodejs-docker/pull/196