### PR TITLE
Test Node.JS 10+12 instead of 8+10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-- 8
 - 10
+- 12
 addons:
   firefox: latest
 before_script:

--- a/test/node/web_apis/api_compat_data-test.es6.js
+++ b/test/node/web_apis/api_compat_data-test.es6.js
@@ -35,20 +35,10 @@ describe('CompatClassGenerator', () => {
     expect(axioms.length).toBe(2);
   });
 
-  // The behavior of `console.assert` changed in Node.JS 10, which is used
-  // internally in foam2. This means the expected behavior depends on the
-  // Node.JS version.
-  // See https://github.com/GoogleChromeLabs/confluence/issues/338
-  if (parseInt(process.versions.node.split('.')[0]) >= 10) {
-    it('should ignore duplicate relases', () => {
-      const CompatData = generateClass(true);
-      const axioms = CompatData.getAxiomsByClass(org.chromium.apis.web.CompatProperty);
-      expect(axioms.length).toBe(1);
-    });
-  } else {
-    it('should throw for duplicate relases', () => {
-      expect(() => generateClass(true)).toThrow();
-    });
-  }
+  it('should ignore duplicate relases', () => {
+    const CompatData = generateClass(true);
+    const axioms = CompatData.getAxiomsByClass(org.chromium.apis.web.CompatProperty);
+    expect(axioms.length).toBe(1);
+  });
 
 });


### PR DESCRIPTION
The Node.JS version in prod has already silently been upgraded from 8 to
10: https://github.com/GoogleChromeLabs/confluence/pull/363

At some point it will probably be updated to 12, so test that and drop
support for 8 in tests.