### PR TITLE
Avoid passing Error objects to Jasmine's done callback

### DIFF
--- a/test/any/confluence/set_ops-test.es6.js
+++ b/test/any/confluence/set_ops-test.es6.js
@@ -89,7 +89,10 @@ describe('Set ops', () => {
       }
 
       set.select(E.SET_MINUS(subtrahend))
-          .then(done.fail, done);
+          .then(done.fail, error => {
+            expect(error.message).toBe('ErrorDAO: Error on select()');
+            done();
+          });
     });
 
     it('should reject when subtrahend rejects find()', done => {
@@ -104,7 +107,10 @@ describe('Set ops', () => {
       }
 
       set.select(E.SET_MINUS(subtrahend))
-          .then(done.fail, done);
+          .then(done.fail, error => {
+            expect(error.message).toBe('ErrorDAO: Error on find()');
+            done();
+          });
     });
   });
 

--- a/test/any/dao/http_json_dao-test.es6.js
+++ b/test/any/dao/http_json_dao-test.es6.js
@@ -109,7 +109,10 @@ describe('HttpJsonDAO', () => {
                        foam.json.Strict.stringify(array));
     ctx.register(test.NonEmptyArrayHTTPRequest, 'foam.net.HTTPRequest');
 
-    createHttpJsonDAO([], ctx).select().then(done.fail, done);
+    createHttpJsonDAO([], ctx).select().then(done.fail, error => {
+      expect(error.message).toBe('Class "test.Item" is not whitelisted.');
+      done();
+    });
   });
 
   it('should succeed when URL is safe, using custom safety params', done => {
@@ -132,7 +135,10 @@ describe('HttpJsonDAO', () => {
 
     createHttpJsonDAO([], ctx, {
       url: 'https://evil.com/something/maniacal',
-    }).select().then(done.fail, done);
+    }).select().then(done.fail, error => {
+      expect(error.message).toBe('HttpJsonDAO: URL is not safe: https://evil.com/something/maniacal');
+      done();
+    });
   });
 
   it('should not issue requests or instantiate delegate, in Serializable flavour', done => {


### PR DESCRIPTION
This is the cause of "DEPRECATION: done callback received an Error
object. Jasmine 3.0 will treat this as a failure" messages when
running the tests, and blocks upgrading Jasmine and other testing
packages.