### PR TITLE
Drop the engines block in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
   "name": "web-api-confluence-dashboard",
   "version": "0.0.1",
   "description": "Web API Confluence Dashboard",
-  "engines": {
-    "node": "8.11.1"
-  },
   "scripts": {
     "coverage": "npm run coverageNode && npm run coverageWeb && istanbul-combine -d .coverage -p summary -r lcov -r html -r json -b . .node_coverage/coverage.json .web_coverage/*/coverage*.json && istanbul check-coverage --config config/istanbul.yml \".coverage/**/coverage*.json\"",
     "coverageNode": "JASMINE_CONFIG_PATH=./config/jasmine.json istanbul cover --config config/istanbul.yml --dir .node_coverage -- jasmine",


### PR DESCRIPTION
It's advisoy only: https://docs.npmjs.com/files/package.json#engines

It's also been wrong for a long time.