### PR TITLE
Log and ignore promise rejection in ApiServiceDAO delegate

### DIFF
--- a/lib/dao/api_service_dao.es6.js
+++ b/lib/dao/api_service_dao.es6.js
@@ -22,6 +22,8 @@ foam.CLASS({
     'foam.dao.RestDAO',
     'org.chromium.apis.web.WorkerDAO',
   ],
+  
+  import: ['warn'],
 
   properties: [
     {

--- a/lib/dao/api_service_dao.es6.js
+++ b/lib/dao/api_service_dao.es6.js
@@ -63,7 +63,7 @@ foam.CLASS({
         clientDAO.limit(1).select().then(() => {
           this.delegate = clientDAO;
         }, (err) => {
-          console.error(err);
+          this.warn(`Caching all ${this.of.id} data failed. Using REST API instead. Reason: ${err}`);
         });
 
         // Initially, hit network directly to fetch data.

--- a/lib/dao/api_service_dao.es6.js
+++ b/lib/dao/api_service_dao.es6.js
@@ -62,6 +62,8 @@ foam.CLASS({
         // Change delegate to client once it has finished caching in worker.
         clientDAO.limit(1).select().then(() => {
           this.delegate = clientDAO;
+        }, (err) => {
+          console.error(err);
         });
 
         // Initially, hit network directly to fetch data.

--- a/lib/dao/api_service_dao.es6.js
+++ b/lib/dao/api_service_dao.es6.js
@@ -22,7 +22,7 @@ foam.CLASS({
     'foam.dao.RestDAO',
     'org.chromium.apis.web.WorkerDAO',
   ],
-  
+
   import: ['warn'],
 
   properties: [


### PR DESCRIPTION
Because this turns into an unhandled promise rejection, after
upgrading to Jasmine 3, it would cause some subsequent tests to fail
in a mysterious manner. (Pinpointing the cause was not easy.)

Note that this would have been caught by this lint rule:
https://github.com/xjamundx/eslint-plugin-promise/blob/master/docs/rules/catch-or-return.md