### PR TITLE
Enable eslint:recommended lint rules with some exceptions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,10 +3,12 @@
     "browser": true,
     "node": true
   },
-  "extends": ["google"],
+  "extends": ["eslint:recommended", "google"],
   "rules": {
     "camelcase": "off",
+    "no-console": "off",
     "no-invalid-this": "off",
+    "no-undef": "off",
     "no-unused-vars": "off",
     "new-cap": ["error", {
     	"capIsNew": false

--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -91,7 +91,7 @@ function configurator(config) {
     browserDisconnectTolerance: 5,
     browserNoActivityTimeout: 150000,
   });
-};
+}
 
 configurator.srcGlobs = [
   '../lib/**/*.js',

--- a/lib/confluence/api_count_data.es6.js
+++ b/lib/confluence/api_count_data.es6.js
@@ -8,9 +8,6 @@ foam.CLASS({
   package: 'org.chromium.apis.web',
   documentation: `API counts that Nth release to N-1th release of a browser.
       Counts are: {<total APIs>, <removed APIs>, <added APIs>}.`,
-  documentation: `apiCountData contains the numer of total APIs,
-      new APIs and removed APIs compared to the previous version
-      of this release version.`,
   ids: ['browserName', 'releaseDate'],
   properties: [
     {

--- a/lib/dao/json_dao_container.es6.js
+++ b/lib/dao/json_dao_container.es6.js
@@ -141,7 +141,6 @@ foam.CLASS({
       } else {
         serializableDAO = this.SerializableLocalJsonDAO.create({
           of: cls,
-          path: `${this.basename}/${cls.id}.json`,
           path: this.parseURL_(`${this.basename}/${cls.id}.json`).pathname,
         }, ctx);
       }

--- a/test/any/web_catalog/api_extractor-test.es6.js
+++ b/test/any/web_catalog/api_extractor-test.es6.js
@@ -285,9 +285,9 @@ describe('API extractor', () => {
   });
 
   it('should combine non-built-in prototypes on libraries', (done) => {
-    function method1() {};
+    function method1() {}
     const libProto = {method1};
-    function method2() {};
+    function method2() {}
     const lib = Object.create(libProto, {method2: {value: method2}});
     Promise.all([
       getCatalog({Object, Function}, {key: 'window'}, {}),


### PR DESCRIPTION
https://eslint.org/docs/rules/no-dupe-keys in particular seems useful,
and there were two violations. For `documentation` pick the "best"
documentation, and for `path` pick the last, since that leaves
behavior unchanged and it looks correct.