### PR TITLE
Enable the no-undef lint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
   "env": {
+    "es6": true,
+    "jasmine": true,
     "browser": true,
+    "worker": true,
     "node": true
   },
   "extends": ["eslint:recommended", "google"],
@@ -8,7 +11,6 @@
     "camelcase": "off",
     "no-console": "off",
     "no-invalid-this": "off",
-    "no-undef": "off",
     "no-unused-vars": "off",
     "new-cap": ["error", {
     	"capIsNew": false
@@ -19,6 +21,8 @@
     "require-jsdoc": "off"
   },
   "globals": {
+    "angular": false,
+    "org": false,
     "foam": false
   },
   "parserOptions": {

--- a/lib/controller/api_confluence.es6.js
+++ b/lib/controller/api_confluence.es6.js
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 'use strict';
 
+/* global M */
+
 require('angular');
 
 require('../chart/time_series_chart.es6.js');

--- a/lib/controller/api_confluence.es6.js
+++ b/lib/controller/api_confluence.es6.js
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 'use strict';
 
+// M is Materialize
 /* global M */
 
 require('angular');

--- a/main/forkScript.js
+++ b/main/forkScript.js
@@ -57,7 +57,7 @@ function getMode(str) {
 
   if (mode) return mode;
 
-  const modeNames = Enum.VALUES.map(function(value) {
+  const modeNames = pkg.DataSource.VALUES.map(function(value) {
     return value.name;
   });
   panic(`Invalid ${pkg.DataSource.name} (not one of "${modeNames

--- a/test/any/dao/http_json_dao-test.es6.js
+++ b/test/any/dao/http_json_dao-test.es6.js
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 'use strict';
 
+/* global test */
+
 describe('HttpJsonDAO', () => {
   let pkg;
   beforeAll(() => {

--- a/test/any/web_apis/api_compat_data-test.es6.js
+++ b/test/any/web_apis/api_compat_data-test.es6.js
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 'use strict';
 
+/* global describeRawTableCellFormatterTests */
+
 describe('CompatProperty', () => {
   let pkg;
   beforeEach(() => {


### PR DESCRIPTION
This did reveal a real mistake in main/forkScript.js, although in code
that doesn't really matter if it's broken because it would
`process.exit(1)` right afterwards anyway.