### PR TITLE
Don't use babel when running tests using karma

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -108,15 +108,6 @@ configurator.webpackConfig = {
   module: {
     rules: [
       {
-        test: C.ES6_REG_EXP,
-        use: [
-          {
-            loader: 'babel-loader',
-            options: C.ES6_LOADER_OPTIONS_DEV,
-          },
-        ],
-      },
-      {
         test: /\.html$/,
         use: [{loader: 'html-loader'}],
       },


### PR DESCRIPTION
Currently instrumentation is running after babel, which results in
incorrect and nonsensical coverage information. The node vs. web
coverage here is an example:
https://codecov.io/gh/GoogleChromeLabs/confluence/src/f6802df5a6be89042a1db1e7b82f0a0a90906caf/lib/dao/indexed_dao.es6.js

This could be fixed by changing the order:
https://github.com/GoogleChromeLabs/confluence/pull/404

However, it's not clear if that's correct:
https://github.com/webpack-contrib/istanbul-instrumenter-loader/issues/86

There's no need to run Babel to test stable versions of Chrome or Firefox,
so just skip babel-loader.