### PR TITLE
Try `enforce: 'post'` for istanbul-instrumenter-loader

### DIFF
--- a/config/karma.coverage.conf.js
+++ b/config/karma.coverage.conf.js
@@ -16,6 +16,7 @@ webpack.module.rules = [
   {
     test: /\.js$/,
     use: {loader: 'istanbul-instrumenter-loader'},
+    enforce: 'post',
     include: path.resolve(__dirname, '../lib/'),
   },
 ].concat(webpack.module.rules);


### PR DESCRIPTION
https://github.com/webpack-contrib/istanbul-instrumenter-loader#with-babel