### PR TITLE
Set and enforce webpack asset and entry point size limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,23 @@ language: node_js
 
 matrix:
   include:
-  - name: node10
+  - name: lint
     node_js: 10
     script:
     - npm run lint
+    # Run webpack to check size limits.
+    - npx webpack --config config/webpack.prod.js
+    after_script:
+    - true # don't run codecov
+
+  - name: node10
+    node_js: 10
+    script:
     - npm run coverageNode
 
   - name: node12
     node_js: 12
     script:
-    - npm run lint
     - npm run coverageNode
 
   - name: chrome

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -44,4 +44,12 @@ module.exports = merge(common, {
       }),
     ],
   },
+  performance: {
+    // These size limits are *much* larger than webpack's default
+    // recommendation of 250kb, but are combined with 'error' to ensure that
+    // they don't grow accidentally beyond the current size.
+    hints: 'error',
+    maxAssetSize: 1.5*1024*1024,
+    maxEntrypointSize: 2.2*1024*1024,
+  },
 });


### PR DESCRIPTION
https://webpack.js.org/configuration/performance/

Run webpack with prod config in Travis to avoid regressions.