### PR TITLE
Don't use URL constructor for protocol-less file system paths

### DIFF
--- a/lib/dao/json_dao_container.es6.js
+++ b/lib/dao/json_dao_container.es6.js
@@ -125,7 +125,7 @@ foam.CLASS({
       } else {
         serializableDAO = this.SerializableLocalJsonDAO.create({
           of: cls,
-          path: new URL(`${this.basename}/${cls.id}.json`).pathname,
+          path: `${this.basename}/${cls.id}.json`,
         }, ctx);
       }
       // Set propertyIndexGroups after other properties; its validation


### PR DESCRIPTION
This regressed with https://github.com/GoogleChromeLabs/confluence/pull/409.

The code path isn't tested, but is used by local_og_to_confluence.sh.

The problem is that `require('url').parse('/a/b/c.json')` returns a
URL with `protocol` null and pathame '/a/b/c.json', while the URL
constructor throws since it's an invalid URL.

Fixing this by prepending `file:` wouldn't even normalize the
pathname, so just don't use the URL constructor.