### PR TITLE
Revert "Use the URL constructor instead of url module"

### DIFF
--- a/lib/compat.es6.js
+++ b/lib/compat.es6.js
@@ -25,6 +25,19 @@ foam.CLASS({
       required: true,
     },
     {
+      class: 'Function',
+      name: 'parseURL_',
+      transient: true,
+      factory: function() {
+        if (foam.isServer) {
+          const url = require('url');
+          return url.parse.bind(url);
+        } else {
+          return (str) => new URL(str);
+        }
+      },
+    },
+    {
       class: 'FObjectProperty',
       of: 'foam.json.Parser',
       name: 'parser',
@@ -82,7 +95,7 @@ foam.CLASS({
       code: function() {
         let url;
         try {
-          url = new URL(this.classURL);
+          url = this.parseURL_(this.classURL);
         } catch (err) {
           return Promise.reject(err);
         }

--- a/lib/dao/http_json_dao.es6.js
+++ b/lib/dao/http_json_dao.es6.js
@@ -65,6 +65,17 @@ foam.CLASS({
       },
     },
     {
+      class: 'Function',
+      name: 'createURL',
+      documentation: 'Platform-independent URL factory function.',
+      transient: true,
+      factory: function() {
+        return foam.isServer ?
+            (str) => require('url').parse(str) :
+            (str) => new URL(str);
+      },
+    },
+    {
       name: 'promise',
       transient: true,
       factory: function() {
@@ -107,7 +118,7 @@ foam.CLASS({
       if (!foam.String.isInstance(url)) {
         throw new Error('HttpJsonDAO: URL is not a String');
       }
-      if (!this.urlIsSafe(new URL(url))) {
+      if (!this.urlIsSafe(this.createURL(url))) {
         throw new Error(`HttpJsonDAO: URL is not safe: ${url}`);
       }
     },

--- a/lib/dao/json_dao_container.es6.js
+++ b/lib/dao/json_dao_container.es6.js
@@ -108,6 +108,22 @@ foam.CLASS({
         return this.StubFactorySingleton.create();
       },
     },
+    {
+      // TODO(markdittmer): This is the second time this browser/node code smell
+      // has come up for URL parsing. Perhaps move to some kind of interop
+      // utility class.
+      class: 'Function',
+      name: 'parseURL_',
+      transient: true,
+      factory: function() {
+        if (foam.isServer) {
+          const url = require('url');
+          return url.parse.bind(url);
+        } else {
+          return (str) => new URL(str);
+        }
+      },
+    },
   ],
 
   methods: [
@@ -125,7 +141,7 @@ foam.CLASS({
       } else {
         serializableDAO = this.SerializableLocalJsonDAO.create({
           of: cls,
-          path: new URL(`${this.basename}/${cls.id}.json`).pathname,
+          path: this.parseURL_(`${this.basename}/${cls.id}.json`).pathname,
         }, ctx);
       }
       // Set propertyIndexGroups after other properties; its validation

--- a/main/relational_to_compat.es6.js
+++ b/main/relational_to_compat.es6.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const process = require('process');
+const url = require('url');
 
 require('foam2');
 
@@ -42,7 +43,7 @@ if (process.argv.length !== 3) {
   process.exit(1);
 }
 
-const dataUrl = new URL(process.argv[2]);
+const dataUrl = url.parse(process.argv[2]);
 if (dataUrl.protocol !== 'file:' && dataUrl.protocol !== 'https:') {
   console.error('BaseConfluenceDataURL parameter must be file: or https: URL');
 }
@@ -51,7 +52,7 @@ const container = pkg.JsonDAOContainer.create({
   mode: dataUrl.protocol === 'file:' ? pkg.DataSource.LOCAL :
       pkg.DataSource.HTTP,
   basename: dataUrl.protocol === 'file:' ? dataUrl.pathname :
-      dataUrl.toString(),
+      url.format(dataUrl),
 }, logger);
 
 logger.info('Gathering Confluence data from JSON');

--- a/main/relational_to_grid.es6.js
+++ b/main/relational_to_grid.es6.js
@@ -5,6 +5,7 @@
 
 const fs = require('fs');
 const process = require('process');
+const url = require('url');
 
 require('foam2');
 
@@ -36,7 +37,7 @@ if (process.argv.length !== 3) {
   process.exit(1);
 }
 
-const dataUrl = new URL(process.argv[2]);
+const dataUrl = url.parse(process.argv[2]);
 if (dataUrl.protocol !== 'file:' && dataUrl.protocol !== 'https:') {
   console.error('BaseConfluenceDataURL parameter must be file: or https: URL');
 }
@@ -44,7 +45,7 @@ if (dataUrl.protocol !== 'file:' && dataUrl.protocol !== 'https:') {
 const container = pkg.JsonDAOContainer.create({
   mode: dataUrl.protocol === 'file:' ? pkg.DataSource.LOCAL :
       pkg.DataSource.HTTP,
-  basename: dataUrl.protocol === 'file:' ? dataUrl.pathname : dataUrl.toString(),
+  basename: dataUrl.protocol === 'file:' ? dataUrl.pathname : url.format(dataUrl),
 }, logger);
 
 logger.info('Gathering Confluence data from JSON');


### PR DESCRIPTION
This reverts https://github.com/GoogleChromeLabs/confluence/pull/409.