### PR TITLE
Make an async test really async (was broken)

### DIFF
--- a/test/any/confluence/metric_computer_runner-test.es6.js
+++ b/test/any/confluence/metric_computer_runner-test.es6.js
@@ -110,14 +110,14 @@ describe('MetricComputerRunner', function() {
         .create(null, container);
   });
   describe('getOrderedListOfReleaseDates()', function() {
-    it('gets correct dates from releaseWebInterfaceJunctionDAO', function() {
+    it('gets correct dates from releaseWebInterfaceJunctionDAO', function(done) {
       runner.getOrderedListOfReleaseDates().then((dateArr) => {
         expect(dateArr).toEqual([
           new Date('2014-02-01'),
           new Date('2015-01-10'),
           new Date('2015-04-01'),
         ]);
-      });
+      }).then(done, done.fail);
     });
   });
   describe('getLatestReleaseFromEachBrowserAtDate()', function() {


### PR DESCRIPTION
This was caught by eslint-plugin-promise, but that config isn't being
added at this point.