### PR TITLE
Increase maxAssetSize and maxEntrypointSize

### DIFF
--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -49,7 +49,7 @@ module.exports = merge(common, {
     // recommendation of 250kb, but are combined with 'error' to ensure that
     // they don't grow accidentally beyond the current size.
     hints: 'error',
-    maxAssetSize: 1.5*1024*1024,
-    maxEntrypointSize: 2.2*1024*1024,
+    maxAssetSize: 2*1024*1024,
+    maxEntrypointSize: 2.5*1024*1024,
   },
 });


### PR DESCRIPTION
With the recent updates, our 3rd-party dependencies have grown over
1.5MiB, so we need to adjust the maxAssetSize to suppress an error;
maxEntrypointSize also needs to be adjusted as it includes vendors, too.

TBR @foolip to unblock release