### PR TITLE
Allow more (30) open Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,4 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  open-pull-requests-limit: 30


### PR DESCRIPTION
There are 32 dependencies, so this should be enough. 5 is not.
