### PR TITLE
Cut out crypto and url node libs from webpack bundle

### DIFF
--- a/config/webpack.common.js
+++ b/config/webpack.common.js
@@ -73,7 +73,9 @@ module.exports = {
     extensions: ['.js'],
   },
   node: {
-    fs: 'empty',
+    crypto: 'empty',
     dns: 'empty',
+    fs: 'empty',
+    url: 'empty',
   },
 };

--- a/config/webpack.prod.js
+++ b/config/webpack.prod.js
@@ -50,6 +50,6 @@ module.exports = merge(common, {
     // they don't grow accidentally beyond the current size.
     hints: 'error',
     maxAssetSize: 2*1024*1024,
-    maxEntrypointSize: 2.5*1024*1024,
+    maxEntrypointSize: 2*1024*1024,
   },
 });


### PR DESCRIPTION
Crypto in particular takes a lot of space. Removing it allows lowering
the limit.
